### PR TITLE
fix: reopening About window

### DIFF
--- a/tilia/ui/windows/about.py
+++ b/tilia/ui/windows/about.py
@@ -1,5 +1,4 @@
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QCloseEvent
 from PyQt6.QtWidgets import QLabel, QVBoxLayout, QMainWindow, QDialog
 
 import tilia.constants

--- a/tilia/ui/windows/about.py
+++ b/tilia/ui/windows/about.py
@@ -1,8 +1,10 @@
 from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QCloseEvent
 from PyQt6.QtWidgets import QLabel, QVBoxLayout, QMainWindow, QDialog
 
 import tilia.constants
 
+from tilia.requests import Post, post
 
 class About(QDialog):
     def __init__(self, parent: QMainWindow):
@@ -34,3 +36,7 @@ class About(QDialog):
         layout.addWidget(license_label)
 
         self.show()
+
+    def closeEvent(self, event):        
+        post(Post.WINDOW_ABOUT_CLOSED)
+        return super().closeEvent(event)


### PR DESCRIPTION
- About window was not closed properly and could not be reopened after
  closing as there was no clsoe request sent to remove it from the list
  of already opened windows
About window now posts request to close the window, so that the window is properly removed from the list of opened windows and can be successfully reopened.