### PR TITLE
Format time

### DIFF
--- a/tilia/ui/format.py
+++ b/tilia/ui/format.py
@@ -1,4 +1,6 @@
 def format_media_time(audio_time: float | str) -> str:
-    minutes = str(int(float(audio_time) // 60)).zfill(2)
     seconds_and_fraction = f"{audio_time % 60:.1f}".zfill(4)
-    return f"{minutes}:{seconds_and_fraction}"
+    minutes = int(float(audio_time) // 60)
+    hours = str(minutes // 60) + ':' if minutes >= 60 else ''
+    minutes = str(minutes % 60).zfill(2)
+    return f"{hours}{minutes}:{seconds_and_fraction}"

--- a/tilia/ui/player.py
+++ b/tilia/ui/player.py
@@ -16,8 +16,8 @@ class PlayerToolbar(QToolBar):
 
         self._setup_requests()
 
-        self.current_time_string = "0:00:00"
-        self.duration_string = "0:00:00"
+        self.current_time_string = format_media_time(0)
+        self.duration_string = format_media_time(0)
 
         self.play_action = actions.get_qaction(TiliaAction.MEDIA_TOGGLE_PLAY_PAUSE)
         self.stop_action = actions.get_qaction(TiliaAction.MEDIA_STOP)


### PR DESCRIPTION
closes #99. Hours have a new division if media is more than 60 minutes long.