### PR TITLE
More score bugs

### DIFF
--- a/tilia/parsers/score/musicxml.py
+++ b/tilia/parsers/score/musicxml.py
@@ -259,7 +259,7 @@ def notes_from_musicXML(
                     sign = attribute.find("sign").text
                     line = (
                         int(attr_line.text) - 3
-                        if (attr_line := attribute.find("line"))
+                        if (attr_line := attribute.find("line")) is not None
                         else 0
                     )
                     octave_change = (

--- a/tilia/parsers/score/musicxml.py
+++ b/tilia/parsers/score/musicxml.py
@@ -245,7 +245,11 @@ def notes_from_musicXML(
                     constructor_kwargs = {
                         "fifths": int(attribute.find("fifths").text),
                     }
-                    staff_numbers = list(part_id_to_staves[part_id].keys())
+                    staff_numbers = (
+                        [attribute.get("number")]
+                        if attribute.get("number") is not None
+                        else list(part_id_to_staves[part_id].keys())
+                    )
                     component_kind = ComponentKind.KEY_SIGNATURE
                 case "time":
                     ts_numerator = int(attribute.find("beats").text)
@@ -254,7 +258,11 @@ def notes_from_musicXML(
                         "numerator": ts_numerator,
                         "denominator": ts_denominator,
                     }
-                    staff_numbers = list(part_id_to_staves[part_id].keys())
+                    staff_numbers = (
+                        [attribute.get("number")]
+                        if attribute.get("number") is not None
+                        else list(part_id_to_staves[part_id].keys())
+                    )
                     component_kind = ComponentKind.TIME_SIGNATURE
                 case "clef":
                     sign = attribute.find("sign").text

--- a/tilia/parsers/score/musicxml.py
+++ b/tilia/parsers/score/musicxml.py
@@ -75,7 +75,7 @@ def notes_from_musicXML(
     metric_division = MetricDivision()
 
     sign_to_octave = {"C": 4, "F": 3, "G": 4}
-    sign_to_line = {"C": 0, "F": 1, "G": -1}
+    sign_to_line = {"C": 3, "F": 4, "G": 2}
 
     def _create_component(component_kind: ComponentKind, kwargs: dict) -> int | None:
         component, fail_reason = score_tl.create_component(component_kind, **kwargs)
@@ -266,23 +266,22 @@ def notes_from_musicXML(
                     component_kind = ComponentKind.TIME_SIGNATURE
                 case "clef":
                     sign = attribute.find("sign").text
+                    if sign not in {"C", "F", "G"}:
+                        errors.append(f"<{attribute.tag}> - {sign} not implemented")
+                        continue
+
                     line = (
-                        int(attr_line.text) - 3
+                        int(attr_line.text)
                         if (attr_line := attribute.find("line")) is not None
-                        else 0
-                    )
+                        else sign_to_line[sign]
+                    ) - 3
                     octave_change = (
                         int(o.text)
                         if (o := attribute.find("clef-octave-change"))
                         else 0
                     )
-
-                    if sign not in {"C", "F", "G"}:
-                        errors.append(f"<{attribute.tag}> - {sign} not implemented")
-                        continue
-
                     constructor_kwargs = {
-                        "line_number": sign_to_line[sign] - line,
+                        "line_number": line,
                         "icon": Clef.ICON.get(sign),
                         "step": NOTE_NAME_TO_INT[sign],
                         "octave": sign_to_octave[sign] + octave_change,

--- a/tilia/ui/timelines/score/element/time_signature.py
+++ b/tilia/ui/timelines/score/element/time_signature.py
@@ -22,7 +22,12 @@ class TimeSignatureUI(TimelineUIElementWithCollision):
         return time_x_converter.get_x_by_time(self.get_data("time"))
 
     def body_y(self):
-        return self.MARGIN_Y * self.timeline_ui.get_scale_for_symbols_above_staff()
+        return (
+            self.MARGIN_Y * self.timeline_ui.get_scale_for_symbols_above_staff()
+            + self.timeline_ui.get_y_for_symbols_above_staff(
+                self.get_data("staff_index")
+            )
+        )
 
     def _setup_body(self):
         self.body = TimeSignatureBody(
@@ -53,12 +58,9 @@ class TimeSignatureUI(TimelineUIElementWithCollision):
             self.x
             + self.x_offset
             + (self.margin_x if self.x_offset is not None else 0),
-            self.timeline_ui.get_y_for_symbols_above_staff(
-                self.get_data("staff_index")
-            ),
+            self.body_y(),
         )
         self.body.set_height(self.get_body_digit_height())
-        self.body.setY(self.body_y())
 
     def on_components_deserialized(self):
         self.body.set_height(self.get_body_digit_height())
@@ -143,4 +145,5 @@ class TimeSignatureBody(QGraphicsItem):
             bounding_rect = bounding_rect.united(item.boundingRect())
         return bounding_rect
 
-    def paint(self, painter, option, widget): ...
+    def paint(self, painter, option, widget):
+        ...


### PR DESCRIPTION
Some bugs mentioned in #312, including:
- incorrect parsing of clefs
- incorrect clef/key signature/time signature when not importing the first measure
- overlapping time signature in block display