### PR TITLE
Fix crash when inputting some harmony extensions

### DIFF
--- a/tests/ui/dialogs/test_select_harmony_params.py
+++ b/tests/ui/dialogs/test_select_harmony_params.py
@@ -9,7 +9,12 @@ from tilia.ui.timelines.harmony.utils import INT_TO_APPLIED_TO_SUFFIX
 
 def parse_text(text):
     dialog = SelectHarmonyParams()
-    dialog.line_edit.insert(text)
+    # insert one character at a time
+    # to ensure no errors will be raised
+    # while the user is typing
+    for i in range(len(text)):
+        dialog.line_edit.clear()
+        dialog.line_edit.insert(text[: i + 1])
     return dialog.get_result()
 
 
@@ -79,3 +84,13 @@ class TestChordSymbolParsing:
         params = parse_text("G/A")
         assert params["step"] == 4
         assert params["inversion"] == 0  # fourth inversion is not currently supported
+
+    @pytest.mark.parametrize(
+        "extension",
+        ["7#9", "7#11", "m713", "7b9", "11", "7(b13)", "7(b9,#11)", "(b9,#13)"],
+    )
+    def test_parse_with_extensions_does_not_crash(self, extension, qtui):
+        # This only tests that it doesn't crash
+        # extensions are not currently supported
+        params = parse_text("C" + extension)
+        assert params["step"] == 0

--- a/tilia/timelines/harmony/components/harmony.py
+++ b/tilia/timelines/harmony/components/harmony.py
@@ -168,7 +168,9 @@ def _get_music21_object_from_text(
     if text.startswith(tuple(NOTE_NAME_TO_INT)) and not prefixed_accidental:
         try:
             return music21.harmony.ChordSymbol(text), "chord"
-        except ValueError:
+        # This is a bare expect because I don't know
+        # exactly what exceptions music21 can throw.
+        except:  # noqa
             pass
     elif text.startswith(("I", "i", "V", "v")):
         try:

--- a/tilia/timelines/harmony/components/harmony.py
+++ b/tilia/timelines/harmony/components/harmony.py
@@ -132,7 +132,7 @@ class Harmony(PointLikeTimelineComponent):
         self._inversion = value
 
 
-def get_params_from_text(text, key):
+def get_params_from_text(text: str, key: str):
     music21_object, object_type = _get_music21_object_from_text(text, key)
     if not object_type:
         return False, None
@@ -157,7 +157,11 @@ def _replace_special_abbreviations(text):
     return text
 
 
-def _get_music21_object_from_text(text, key):
+def _get_music21_object_from_text(
+    text: str, key: str
+) -> tuple[music21.harmony.ChordSymbol | music21.roman.RomanNumeral, str] | tuple[
+    None, None
+]:
     text, prefixed_accidental = _extract_prefixed_accidental(text)
     text = _format_postfix_accidental(text)
     text = _replace_special_abbreviations(text)
@@ -178,7 +182,9 @@ def _get_music21_object_from_text(text, key):
     return None, None
 
 
-def _get_params_from_music21_object(obj, kind):
+def _get_params_from_music21_object(
+    obj: music21.harmony.ChordSymbol | music21.roman.RomanNumeral, kind: str
+) -> dict:
     step = NOTE_NAME_TO_INT[obj.root().step]
     accidental = int(obj.root().alter)
     inversion = obj.inversion() if obj.inversion() else 0


### PR DESCRIPTION
Fixes #348.

This only fixes the crash, it does not implement extension parsing.