### PR TITLE
Fix crashes when importing MusicXML

### DIFF
--- a/tests/timelines/score/fixtures.py
+++ b/tests/timelines/score/fixtures.py
@@ -26,7 +26,7 @@ def score_tl(tls):
 def note(score_tl):
     score_tl.create_component(ComponentKind.STAFF, 0, 5)
     score_tl.create_component(ComponentKind.CLEF, 0, 0, shorthand=Clef.Shorthand.TREBLE)
-    return score_tl.create_component(ComponentKind.NOTE, 0, 0, 0, 0, 3, 0)[0]
+    return score_tl.create_component(ComponentKind.NOTE, 0, 1, 0, 0, 3, 0)[0]
 
 
 @pytest.fixture

--- a/tests/ui/timelines/score/test_score_timeline_ui.py
+++ b/tests/ui/timelines/score/test_score_timeline_ui.py
@@ -148,7 +148,7 @@ def test_missing_staff_deletes_timeline(
                 },
                 3: {
                     "start": 0,
-                    "end": 0,
+                    "end": 1,
                     "step": 0,
                     "accidental": 0,
                     "octave": 3,
@@ -163,6 +163,7 @@ def test_missing_staff_deletes_timeline(
             "components_hash": "",
         }
     }
+    file_data["media_metadata"]["media length"] = 1
 
     tmp_file = tmp_path / "test.tla"
     tmp_file.write_text(json.dumps(file_data), encoding="utf-8")

--- a/tilia/parsers/score/musicxml.py
+++ b/tilia/parsers/score/musicxml.py
@@ -132,7 +132,15 @@ def notes_from_musicXML(
         }
 
         for attributes in part.iter("attributes"):
-            measure_number = float(attributes.getparent().get("number"))
+            parent = attributes.getparent()
+            number = parent.get("number")
+            try:
+                measure_number = float(number)
+            except ValueError:
+                # implicit measures are not yet implemented
+                # so we don't parse attributes in them
+                if parent.tag == "measure" and parent.get("implicit") == "yes":
+                    continue
             prev_divs = 0
             cur_div = 0
             for prev_note in attributes.itersiblings(

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -311,7 +311,9 @@ class BeatTimeline(Timeline):
 
             # interpolate between beats to get new time
             new_time = start.time + (metric_fraction - keys[idx - 1]) / (
-                metric_fraction_diff if metric_fraction_diff != 0 else 1
+                metric_fraction_diff
+                if not isclose(metric_fraction_diff, 0, abs_tol=0.001)
+                else 1
             ) * (end_time - start.time)
 
             index = bisect(times, new_time)


### PR DESCRIPTION
This fixes crashes when import some MusicXML files. See #354 for examples.

Closes #354.

## Skips implicit measure in `parse_attributes` function
This prevents us from having to deal with measure numbers as `str`.

## Handles rounding error on `get_time_by_measure`
This was leading to score timeline components being created out-of-bounds, which led to crashes when trying to get a clef from the cache.

## Adds validation to score component times
The components mentioned above wouldn't have been created in the first place if their times were validated. We need to implement validation for other score timeline component's attributes at some point.

