### PR TITLE
fix: media path = `.` when no media is loaded

### DIFF
--- a/tilia/file/common.py
+++ b/tilia/file/common.py
@@ -30,7 +30,9 @@ def are_tilia_data_equal(data1: dict, data2: dict) -> bool:
 
 def write_tilia_file_to_disk(file: TiliaFile, path: str | Path):
     file.file_path = Path(file.file_path).as_posix()
-    if not re.match(tilia.constants.YOUTUBE_URL_REGEX, file.media_path):
+    if file.media_path and not re.match(
+        tilia.constants.YOUTUBE_URL_REGEX, file.media_path
+    ):
         file.media_path = Path(file.media_path).as_posix()
     with open(path, "w", encoding="utf-8") as f:
         json.dump(file.__dict__, f, **JSON_CONFIG)


### PR DESCRIPTION
This lead to an error saying the media type/extension was invalid.

This should still go into v0.6 (sorry).