### PR TITLE
fix: crash when using `timeline <kind> import` CLI command

### DIFF
--- a/tilia/parsers/csv/__init__.py
+++ b/tilia/parsers/csv/__init__.py
@@ -1,0 +1,1 @@
+from . import hierarchy, marker, beat, harmony

--- a/tilia/parsers/score/__init__.py
+++ b/tilia/parsers/score/__init__.py
@@ -1,0 +1,1 @@
+from . import musicxml

--- a/tilia/ui/cli/timelines/imp.py
+++ b/tilia/ui/cli/timelines/imp.py
@@ -191,7 +191,6 @@ def import_timeline(namespace):
 
     tl.clear()
 
-    errors = None
     if tl_kind == "marker":
         tl: MarkerTimeline
         if measure_or_time == "by-measure":


### PR DESCRIPTION
The import logic was wrong, but tests didn't fail because the modules where already imported earlier in the session.