### PR TITLE
fix: error message when scaling media & invalid media unloading previous

### DIFF
--- a/tilia/media/player/qtplayer.py
+++ b/tilia/media/player/qtplayer.py
@@ -64,15 +64,11 @@ class QtPlayer(Player):
 
     def _init_player(self):
         self.player = QMediaPlayer()
-        self.player.durationChanged.connect(self.on_media_duration_available)
         self.player.setAudioOutput(self.audio_output)
 
     def on_media_load_done(self, path, start, end):
         super().on_media_load_done(path, start, end)
         post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
-
-    def on_media_duration_available(self, duration):
-        super().on_media_duration_available(duration / 1000)
 
     def on_audio_outputs_changed(self) -> None:
         """
@@ -90,7 +86,11 @@ class QtPlayer(Player):
             self.player.setSource(QUrl.fromLocalFile(media_path))
             return True
 
-        return load_media(media_path)
+        success = load_media(media_path)
+        if success:
+            # Divides by 1000 as durations is expected to be in miliseconds
+            self.on_media_duration_available(self.player.duration() / 1000)
+        return success
 
     def _engine_get_current_time(self):
         return self.player.position() / 1000


### PR DESCRIPTION
@azfoo, I am not entirely sure how the `wait_for_signal` wrapper works, so take an extra careful look at this one.

The callback triggered by the media duration being available was being called before `wait_for_signal` when the wrapper resumed the event loop with `loop.exec()`. As the user takes some time to click the dialog, the wrapper ended up timing out and returning `False` as a success value, which triggered the error message.

This also somehow takes care of the previous valid media being unloaded when invalid files tried to be loaded.

I didn't find a way to manually test this. The whole media load process is fragile, so I suggest we redo manual tests before releasing.

Closes #440.
Closes #425.