### PR TITLE
fix: use QGraphicsItemGroup for TimeSignatureBody to fix missing paint (#428)

### DIFF
--- a/tilia/ui/timelines/score/element/time_signature.py
+++ b/tilia/ui/timelines/score/element/time_signature.py
@@ -1,6 +1,6 @@
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QPixmap
-from PySide6.QtWidgets import QGraphicsItem, QGraphicsPixmapItem
+from PySide6.QtWidgets import QGraphicsItemGroup, QGraphicsPixmapItem
 
 from tilia.ui.coords import time_x_converter
 from tilia.ui.timelines.score.element.with_collision import (
@@ -75,7 +75,7 @@ class TimeSignatureUI(TimelineUIElementWithCollision):
         return
 
 
-class TimeSignatureBody(QGraphicsItem):
+class TimeSignatureBody(QGraphicsItemGroup):
     def __init__(
         self,
         x: float,
@@ -143,13 +143,6 @@ class TimeSignatureBody(QGraphicsItem):
 
     def canvas_items(self):
         return self.numerator_items + self.denominator_items
-
-    def boundingRect(self):
-        items = self.canvas_items()
-        bounding_rect = items[0].boundingRect()
-        for item in items[1:]:
-            bounding_rect = bounding_rect.united(item.boundingRect())
-        return bounding_rect
 
 
 class NumberPixmap(QGraphicsPixmapItem):


### PR DESCRIPTION
TimeSignatureBody subclasses QGraphicsItem directly — a C++ abstract class with a pure virtual paint() method — but never implemented it. The other Qt item classes used in the score (QGraphicsPixmapItem, QGraphicsRectItem, QGraphicsLineItem) already provide a paint() implementation, which is why only the time signature triggers this.

Closes #428