### PR TITLE
fix: close SVG viewer and clear svg_data when score timeline is cleared

### DIFF
--- a/tilia/timelines/score/timeline.py
+++ b/tilia/timelines/score/timeline.py
@@ -59,6 +59,7 @@ class ScoreTLComponentManager(TimelineComponentManager):
         post(Post.SCORE_TIMELINE_COMPONENTS_DESERIALIZED, self.timeline.id)
 
     def clear(self):
+        self.timeline.save_svg_data("")
         super().clear()
         post(Post.SCORE_TIMELINE_CLEAR_DONE, self.timeline.id)
 

--- a/tilia/ui/timelines/score/timeline.py
+++ b/tilia/ui/timelines/score/timeline.py
@@ -473,7 +473,10 @@ class ScoreTimelineUI(TimelineUI):
         self.svg_view.load_svg_data(self.timeline.svg_data)
 
     def reset_svg(self):
-        self.svg_view.deleteLater()
+        try:
+            get(Get.SCORE_VIEWER, self.id).deleteLater()
+        except NoReplyToRequest:
+            pass
 
     def on_left_click(self, item, modifier, double, x, y):
         if item != self.measure_tracker:


### PR DESCRIPTION
## Summary
- Clears `svg_data` in the backend `ScoreTLComponentManager.clear()` so the `svg_view` property cannot recreate a viewer with stale SVG data after clearing.
- Fixes `reset_svg()` to access the existing viewer directly via `get()` instead of going through the `svg_view` property (which auto-creates a viewer if none exists).

## Test plan
- [x] Create a score timeline and import a MusicXML file — SVG viewer opens.
- [x] Clear the score timeline (Edit > Clear) — SVG viewer should close and not reappear.
- [x] Continue using the app — no crash when saving or performing other operations.

Closes #472