### PR TITLE
fix: clamp harmony inversion to valid range when quality changes

### DIFF
--- a/tests/ui/timelines/harmony/test_harmony_ui.py
+++ b/tests/ui/timelines/harmony/test_harmony_ui.py
@@ -23,6 +23,28 @@ class TestRightClick:
         exec_mock.assert_called_once()
 
 
+class TestInversionClamp:
+    def test_letter_symbol_does_not_crash_when_quality_loses_inversion(self, tlui):
+        harmony, _ = tlui.create_harmony(0, quality="dominant-seventh", inversion=3)
+        tlui.timeline.set_component_data(harmony.id, "quality", "major")
+        # Pre-fix: music21.chord.ChordException — no 3rd inversion on triad.
+        _ = tlui.get_element(harmony.id).letter_symbol
+
+    def test_roman_numeral_label_does_not_crash_when_quality_loses_inversion(
+        self, tlui
+    ):
+        harmony, _ = tlui.create_harmony(0, quality="dominant-seventh", inversion=3)
+        tlui.timeline.set_component_data(harmony.id, "quality", "major")
+        _ = tlui.get_element(harmony.id).roman_numeral_label
+
+    def test_letter_symbol_label_omits_dropped_inversion(self, tlui):
+        harmony, _ = tlui.create_harmony(0, quality="dominant-seventh", inversion=3)
+        tlui.timeline.set_component_data(harmony.id, "quality", "major")
+        # Major triad max inversion is 2, so the 3rd-inversion suffix
+        # (INVERSION_TO_INTERVAL[3] == 7) must not appear in the label.
+        assert "/&7" not in tlui.get_element(harmony.id).letter_symbol_label
+
+
 class TestCopyPaste:
     def test_paste_single_into_timeline(self, tlui, tilia_state):
         _, hui = tlui.create_harmony(0)

--- a/tilia/ui/timelines/harmony/elements/harmony.py
+++ b/tilia/ui/timelines/harmony/elements/harmony.py
@@ -7,10 +7,10 @@ from PySide6.QtGui import QColor, QFont
 from PySide6.QtWidgets import QGraphicsItem, QGraphicsTextItem
 
 from tilia.requests import Get, Post, get, post
+from tilia.timelines.harmony.constants import get_inversion_amount
 from tilia.ui.coords import time_x_converter
 from tilia.ui.timelines.base.element import TimelineUIElement
 from tilia.ui.timelines.drag import DragManager
-from tilia.timelines.harmony.constants import get_inversion_amount
 from tilia.ui.timelines.harmony.constants import (
     INT_TO_NOTE_NAME,
     INT_TO_ROMAN,
@@ -71,17 +71,22 @@ class HarmonyUI(TimelineUIElement):
         return self.timeline_ui.get_key_by_time(self.get_data("time"))
 
     @property
+    def clamped_inversion(self):
+        return min(
+            self.get_data("inversion"),
+            get_inversion_amount(self.get_data("quality")),
+        )
+
+    @property
     def letter_symbol(self):
-        quality = self.get_data("quality")
-        inversion = min(self.get_data("inversion"), get_inversion_amount(quality))
         symbol = music21.harmony.ChordSymbol(
             INT_TO_NOTE_NAME[self.get_data("step")]
             + Accidental.get_from_int(
                 "music21",
                 self.get_data("accidental"),
             )
-            + QUALITY_TO_ABBREVIATION[quality],
-            inversion=inversion,
+            + QUALITY_TO_ABBREVIATION[self.get_data("quality")],
+            inversion=self.clamped_inversion,
         )
         applied_to = self.get_data("applied_to")
         if applied_to:
@@ -116,14 +121,13 @@ class HarmonyUI(TimelineUIElement):
 
     @property
     def roman_numeral_label(self):
-        quality = self.get_data("quality")
         return to_roman_numeral(
             self.get_data("step"),
             self.get_data("accidental"),
-            quality,
+            self.get_data("quality"),
             self.key,
             self.get_data("applied_to"),
-            min(self.get_data("inversion"), get_inversion_amount(quality)),
+            self.clamped_inversion,
         )
 
     @property
@@ -154,7 +158,7 @@ class HarmonyUI(TimelineUIElement):
             case 2:
                 figure = figure.replace("##", "`#`#")
 
-        if inversion := self.get_data("inversion"):
+        if inversion := self.clamped_inversion:
             # bass_step = harmony.calculate.bass_step(self.get_data('step'), inversion)
             # figure += '/' + INT_TO_NOTE_NAME[bass_step]  # TODO calculate bass note
             figure += "/&" + str(INVERSION_TO_INTERVAL[inversion])

--- a/tilia/ui/timelines/harmony/elements/harmony.py
+++ b/tilia/ui/timelines/harmony/elements/harmony.py
@@ -10,6 +10,7 @@ from tilia.requests import Get, Post, get, post
 from tilia.ui.coords import time_x_converter
 from tilia.ui.timelines.base.element import TimelineUIElement
 from tilia.ui.timelines.drag import DragManager
+from tilia.timelines.harmony.constants import get_inversion_amount
 from tilia.ui.timelines.harmony.constants import (
     INT_TO_NOTE_NAME,
     INT_TO_ROMAN,
@@ -71,14 +72,16 @@ class HarmonyUI(TimelineUIElement):
 
     @property
     def letter_symbol(self):
+        quality = self.get_data("quality")
+        inversion = min(self.get_data("inversion"), get_inversion_amount(quality))
         symbol = music21.harmony.ChordSymbol(
             INT_TO_NOTE_NAME[self.get_data("step")]
             + Accidental.get_from_int(
                 "music21",
                 self.get_data("accidental"),
             )
-            + QUALITY_TO_ABBREVIATION[self.get_data("quality")],
-            inversion=self.get_data("inversion"),
+            + QUALITY_TO_ABBREVIATION[quality],
+            inversion=inversion,
         )
         applied_to = self.get_data("applied_to")
         if applied_to:
@@ -113,13 +116,14 @@ class HarmonyUI(TimelineUIElement):
 
     @property
     def roman_numeral_label(self):
+        quality = self.get_data("quality")
         return to_roman_numeral(
             self.get_data("step"),
             self.get_data("accidental"),
-            self.get_data("quality"),
+            quality,
             self.key,
             self.get_data("applied_to"),
-            self.get_data("inversion"),
+            min(self.get_data("inversion"), get_inversion_amount(quality)),
         )
 
     @property


### PR DESCRIPTION
## Summary
- Clamps the stored inversion value to the maximum supported by the new chord quality before constructing `music21.harmony.ChordSymbol` and before calling `to_roman_numeral()`.
- Uses the existing `get_inversion_amount(quality)` helper from `tilia.timelines.harmony.constants`.

## Test plan
- [ ] Create a harmony component and set quality to \"dominant seventh\" (3rd inversion supported).
- [ ] Set inversion to 3rd.
- [ ] Change quality to a triad (e.g. major) — no crash, inversion is silently clamped to 2nd.

Closes #468