### PR TITLE
fix: update copyright notice with Anne Foo and GPL v3 license name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ name = "TiLiA"
 version = "0.6.0"
 description = "A GUI for creating and visualizing annotations over audio and video files."
 readme = "README.md"
+license = "GPL-3.0-or-later"
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "chardet<6.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,12 @@ dependencies = [
 ]
 
 [[project.authors]]
-name = "Felipe Defensor et al."
+name = "Felipe Defensor"
 email = "tilia@tilia-app.com"
+
+[[project.authors]]
+name = "Anne Foo"
+email = "45888544+azfoo@users.noreply.github.com"
 
 [project.scripts]
 tilia = "tilia.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,13 +32,11 @@ dependencies = [
     "tomli; python_version < '3.11'"
 ]
 
-[[project.authors]]
-name = "Felipe Defensor"
-email = "tilia@tilia-app.com"
-
-[[project.authors]]
-name = "Anne Foo"
-email = "45888544+azfoo@users.noreply.github.com"
+authors = [
+    {email = "tilia@tilia-app.com"},
+    {name = "Felipe Defensor"},
+    {name = "Anne Foo"}
+]
 
 [project.scripts]
 tilia = "tilia.__main__:main"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -22,3 +22,25 @@ def test_tilia_metadata_not_found():
         assert constants.YEAR == "2022-2026"
         assert constants.AUTHOR == ""
         assert constants.EMAIL == ""
+
+
+def _reload_constants():
+    if "tilia.constants" in sys.modules:
+        del sys.modules["tilia.constants"]
+    import tilia.constants as constants
+
+    return constants
+
+
+def test_authors_list_joined_into_author_string():
+    constants = _reload_constants()
+
+    assert len(constants.AUTHORS) >= 2
+    assert constants.AUTHOR == ", ".join(a for a in constants.AUTHORS if a)
+
+
+def test_notice_uses_license_name_instead_of_copyright_symbol():
+    constants = _reload_constants()
+
+    assert "GNU General Public License v3" in constants.NOTICE
+    assert "Copyright ©" not in constants.NOTICE

--- a/tilia/constants.py
+++ b/tilia/constants.py
@@ -12,7 +12,8 @@ if (toml := Path(__file__).parent.parent / "pyproject.toml").exists():
 
     with open(toml, "rb") as f:
         setupcfg = load(f).get("project", {})
-    AUTHOR = setupcfg.get("authors", [{"name": ""}])[0]["name"]
+    AUTHORS = [a.get("name", "") for a in setupcfg.get("authors", [{"name": ""}])]
+    AUTHOR = ", ".join(a for a in AUTHORS if a)
     EMAIL = setupcfg.get("authors", [{"email": ""}])[0]["email"]
 
 else:
@@ -44,7 +45,7 @@ WEBSITE_URL = setupcfg.get("urls", {}).get("Homepage", "")
 YOUTUBE_URL_REGEX = r"^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube(-nocookie)?\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed\/|v\/)?)([\w\-]+)(\S+)?$"
 NOTICE = f"""
 {APP_NAME}, {setupcfg.get("description", "") if AUTHOR else ""}
-Copyright © {YEAR} {AUTHOR}
+GNU General Public License v3 — {YEAR} {AUTHOR}
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.
 

--- a/tilia/constants.py
+++ b/tilia/constants.py
@@ -46,9 +46,10 @@ EMAIL_URL = "mailto:" + EMAIL
 GITHUB_URL = setupcfg.get("urls", {}).get("Repository", "")
 WEBSITE_URL = setupcfg.get("urls", {}).get("Homepage", "")
 YOUTUBE_URL_REGEX = r"^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube(-nocookie)?\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed\/|v\/)?)([\w\-]+)(\S+)?$"
+COPYRIGHT = f"{APP_NAME} GNU General Public License v3 — {YEAR} {AUTHOR}"
 NOTICE = f"""
-{APP_NAME}, {setupcfg.get("description", "") if AUTHOR else ""}
-GNU General Public License v3 — {YEAR} {AUTHOR}
+{COPYRIGHT}
+{setupcfg.get("description", "") if AUTHOR else ""}
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.
 

--- a/tilia/constants.py
+++ b/tilia/constants.py
@@ -22,9 +22,8 @@ if (toml := Path(__file__).parent.parent / "pyproject.toml").exists():
 else:
     try:
         setupcfg = metadata.metadata("TiLiA").json.copy()
-
-        AUTHOR = re.search(r'"(.*?)"', setupcfg.get("author_email", "")).group(1)
-        EMAIL = re.search(r"<(.*?)>", setupcfg.get("author_email", "")).group(1)
+        AUTHOR = setupcfg.get("author", "")
+        EMAIL = setupcfg.get("author_email", "")
         if "urls" not in setupcfg:
             setupcfg["urls"] = {}
         for url in setupcfg.get("project_url", {}):

--- a/tilia/constants.py
+++ b/tilia/constants.py
@@ -14,7 +14,10 @@ if (toml := Path(__file__).parent.parent / "pyproject.toml").exists():
         setupcfg = load(f).get("project", {})
     AUTHORS = [a.get("name", "") for a in setupcfg.get("authors", [{"name": ""}])]
     AUTHOR = ", ".join(a for a in AUTHORS if a)
-    EMAIL = setupcfg.get("authors", [{"email": ""}])[0]["email"]
+    EMAILS = (
+        e for a in setupcfg.get("authors", [{"email": ""}]) if (e := a.get("email", ""))
+    )
+    EMAIL = next(EMAILS, "")
 
 else:
     try:

--- a/tilia/ui/windows/about.py
+++ b/tilia/ui/windows/about.py
@@ -47,7 +47,7 @@ class About(QDialog):
         line.setFrameShape(QFrame.Shape.HLine)
         line.setFrameShadow(QFrame.Shadow.Sunken)
         license_label = QLabel(
-            f'<a href="#license">{tilia.constants.APP_NAME} Copyright © {tilia.constants.YEAR} {tilia.constants.AUTHOR}</a>'
+            f'<a href="#license">GNU General Public License v3 — {tilia.constants.YEAR} {tilia.constants.AUTHOR}</a>'
         )
         license_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         license_label.linkActivated.connect(self.open_link)

--- a/tilia/ui/windows/about.py
+++ b/tilia/ui/windows/about.py
@@ -46,9 +46,7 @@ class About(QDialog):
         line = QFrame()
         line.setFrameShape(QFrame.Shape.HLine)
         line.setFrameShadow(QFrame.Shadow.Sunken)
-        license_label = QLabel(
-            f'<a href="#license">GNU General Public License v3 — {tilia.constants.YEAR} {tilia.constants.AUTHOR}</a>'
-        )
+        license_label = QLabel(f'<a href="#license">{tilia.constants.COPYRIGHT}</a>')
         license_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         license_label.linkActivated.connect(self.open_link)
 


### PR DESCRIPTION
## Summary
- Adds Anne Foo (azfoo) as a named author in `pyproject.toml`.
- Updates `constants.py` to join all author names from `pyproject.toml` instead of only picking the first one.
- Replaces \"Copyright ©\" with \"GNU General Public License v3\" in the About window label and the NOTICE string.

## Test plan
- [ ] Open About dialog — license label should read \"GNU General Public License v3 — 2022-2026 Felipe Defensor, Anne Foo\" and clicking it should show the full license text.
- [ ] NOTICE string (shown in the license dialog header) should use the same format.

Closes #467