### PR TITLE
fix: zip mac .app using relative path to avoid nested directory structure in archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,7 @@ jobs:
           ls build -ltraR |egrep -v '\.$|\.\.|\.:|\.\/|total|^d' | sed '/^$/d' || true
 
       - name: Upload
-        uses: "softprops/action-gh-release@v2"
+        uses: "softprops/action-gh-release@v3"
         id: release
         with:
           tag_name: ${{github.ref_name}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           echo "\n\nStarting CLI..."
           echo "gtimeout 10 ${{ steps.build-exe.outputs.out-filepath }}/Contents/MacOS/${{ steps.build-exe.outputs.out-filename }} --user-interface=cli" | bash || true
 
-          zip -r9 ${{ steps.build-exe.outputs.zip-filepath }} ${{ steps.build-exe.outputs.out-filepath }} || true
+          (cd "$(dirname "${{ steps.build-exe.outputs.out-filepath }}")" && zip -r9 "${{ steps.build-exe.outputs.zip-filepath }}" "$(basename "${{ steps.build-exe.outputs.out-filepath }}")") || true
           rm -rf ${{ steps.build-exe.outputs.out-filepath }}
 
       - name: Test executable [Windows]

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,21 @@
 .coverage
 .env
+.eggs
+.pytest_cache
+build
+dist
+tilia.egg-info
+venv
+.venv
+__pycache__
+tilia/dev
+
+# IDEs
 .vscode
-/.eggs/
-/.idea/
-/.pytest_cache/
-/build/
-/dist/
-/tilia.egg-info/
-/venv/
-__pycache__/
-tilia/dev/
+.idea
+
+# uv can be useful to create worktrees
+uv.lock
+
+# AI
+CLAUDE.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "TiLiA"
-version = "0.5.15.0"
+version = "0.6.0"
 description = "A GUI for creating and visualizing annotations over audio and video files."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -93,7 +93,8 @@ def _set_out_filename(name: str, version: str):
     if _clean_version(version) == _clean_version(ref_name):
         out_filename = f"{name}-v{version}-{build_os}"
     else:
-        out_filename = f"{name}-v{version}-{ref_name}-{build_os}"
+        safe_ref = ref_name.replace("/", "-")
+        out_filename = f"{name}-v{version}-{safe_ref}-{build_os}"
 
 
 def _get_exe_cmd() -> list[str]:

--- a/tests/ui/test_qtui.py
+++ b/tests/ui/test_qtui.py
@@ -1,4 +1,8 @@
+from types import SimpleNamespace
 from unittest.mock import mock_open, patch
+
+import pytest
+from PySide6.QtCore import QtMsgType
 
 from tests.conftest import parametrize_tlui
 from tests.constants import EXAMPLE_MEDIA_PATH
@@ -7,6 +11,7 @@ from tests.utils import get_actions_in_menu, get_main_window_menu
 from tilia.requests import Get, Post, post
 from tilia.timelines.timeline_kinds import TimelineKind
 from tilia.ui.commands import get_qaction
+from tilia.ui.qtui import TiliaMainWindow
 from tilia.ui.timelines.marker import MarkerTimelineUI
 from tilia.ui.windows import WindowKind
 
@@ -171,3 +176,50 @@ class TestMenus:
         ]
         expected = [get_qaction(action) for action in expected]
         assert set(actions) == set(expected)
+
+
+class TestHandleQtLogMessage:
+    def _ctx(self, file="widget.cpp", line=42):
+        return SimpleNamespace(file=file, line=line)
+
+    def test_fatal_message_raises_exception(self):
+        with pytest.raises(Exception, match=r"\[QtFatalMsg\] widget\.cpp:42 - boom"):
+            TiliaMainWindow.handle_qt_log_message(
+                QtMsgType.QtFatalMsg, self._ctx(), "boom"
+            )
+
+    def test_fatal_exception_message_includes_file_and_line(self):
+        with pytest.raises(Exception) as exc_info:
+            TiliaMainWindow.handle_qt_log_message(
+                QtMsgType.QtFatalMsg, self._ctx(file="core.cpp", line=99), "fatal"
+            )
+        assert "core.cpp:99" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "msg_type",
+        [
+            QtMsgType.QtDebugMsg,
+            QtMsgType.QtInfoMsg,
+            QtMsgType.QtWarningMsg,
+            QtMsgType.QtCriticalMsg,
+        ],
+    )
+    def test_non_fatal_message_calls_logger_error(self, msg_type):
+        ctx = self._ctx(file="view.cpp", line=7)
+        with patch("tilia.ui.qtui.logger") as mock_logger:
+            TiliaMainWindow.handle_qt_log_message(msg_type, ctx, "something happened")
+        mock_logger.error.assert_called_once_with(
+            f"[{msg_type.name}] view.cpp:7 - something happened"
+        )
+
+    def test_non_fatal_message_does_not_raise(self):
+        with patch("tilia.ui.qtui.logger"):
+            TiliaMainWindow.handle_qt_log_message(
+                QtMsgType.QtWarningMsg, self._ctx(), "non-fatal"
+            )
+
+    def test_context_file_none_does_not_raise(self):
+        with patch("tilia.ui.qtui.logger"):
+            TiliaMainWindow.handle_qt_log_message(
+                QtMsgType.QtWarningMsg, self._ctx(file=None, line=-1), "msg"
+            )

--- a/tilia/ui/qtui.py
+++ b/tilia/ui/qtui.py
@@ -85,11 +85,12 @@ class TiliaMainWindow(QMainWindow):
         return super().changeEvent(event)
 
     @staticmethod
-    def handle_qt_log_message(type, _, msg):
+    def handle_qt_log_message(type, context, msg):
+        f_msg = f"[{type.name}] {context.file}:{context.line} - {msg}"
         if type == QtMsgType.QtFatalMsg:
-            raise Exception(f"{type.name}: {msg}")
+            raise Exception(f_msg)
         else:
-            logger.error(f"{type.name}: {msg}")
+            logger.error(f_msg)
 
     def keyPressEvent(self, event: QtGui.QKeyEvent) -> None:
         if event is None:

--- a/tilia/ui/timelines/score/element/time_signature.py
+++ b/tilia/ui/timelines/score/element/time_signature.py
@@ -1,6 +1,6 @@
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QPixmap
-from PySide6.QtWidgets import QGraphicsItem, QGraphicsPixmapItem
+from PySide6.QtWidgets import QGraphicsItemGroup, QGraphicsPixmapItem
 
 from tilia.ui.coords import time_x_converter
 from tilia.ui.timelines.score.element.with_collision import (
@@ -75,7 +75,7 @@ class TimeSignatureUI(TimelineUIElementWithCollision):
         return
 
 
-class TimeSignatureBody(QGraphicsItem):
+class TimeSignatureBody(QGraphicsItemGroup):
     def __init__(
         self,
         x: float,
@@ -143,13 +143,6 @@ class TimeSignatureBody(QGraphicsItem):
 
     def canvas_items(self):
         return self.numerator_items + self.denominator_items
-
-    def boundingRect(self):
-        items = self.canvas_items()
-        bounding_rect = items[0].boundingRect()
-        for item in items[1:]:
-            bounding_rect = bounding_rect.united(item.boundingRect())
-        return bounding_rect
 
 
 class NumberPixmap(QGraphicsPixmapItem):


### PR DESCRIPTION
## Summary

- Fixes the Mac distributable containing the full runner path (`Users/runner/work/desktop/desktop/build/macos-silicon/exe/tilia.app`) inside the zip instead of just `tilia.app` at the root.
- Root cause: `zip` was called with an absolute path for the `.app` bundle, causing the entire directory hierarchy to be embedded in the archive.
- Fix: run the `zip` command from the parent directory of the `.app` (using a subshell `cd`) so only the relative name `tilia.app` appears at the root of the zip.

## Test plan

- [x] Trigger a Mac build via workflow dispatch and verify the downloaded zip extracts `tilia.app` directly at the root with no nested directories.

Closes #477