### PR TITLE
chore: misc non-range cleanup

### DIFF
--- a/tests/ui/timelines/marker/test_marker_timeline_ui.py
+++ b/tests/ui/timelines/marker/test_marker_timeline_ui.py
@@ -355,7 +355,7 @@ class TestElementContextMenu:
 class TestTimelineUIContextMenu:
     @staticmethod
     def get_context_menu(tluis, tl_index=0):
-        return tluis[tl_index].CONTEXT_MENU_CLASS(tluis[tl_index])
+        return tluis[tl_index].CONTEXT_MENU_CLASS(tluis[tl_index], 0, 0)
 
     def test_is_shown_on_right_click(self, tluis, marker_tlui):
         with patch.object(MarkerTimelineUIContextMenu, "exec") as mock:
@@ -615,7 +615,7 @@ class TestMoveInTimelineOrder:
             with Serve(Get.FROM_USER_STRING, (True, name)):
                 commands.execute("timelines.add.marker")
 
-        context_menu = tluis[1].CONTEXT_MENU_CLASS(tluis[1])
+        context_menu = tluis[1].CONTEXT_MENU_CLASS(tluis[1], 0, 0)
         action = get_command_action(context_menu, "timeline.move_up")
         with undoable():
             action.trigger()
@@ -630,7 +630,7 @@ class TestMoveInTimelineOrder:
             with Serve(Get.FROM_USER_STRING, (True, name)):
                 commands.execute("timelines.add.marker")
 
-        context_menu = tluis[1].CONTEXT_MENU_CLASS(tluis[1])
+        context_menu = tluis[1].CONTEXT_MENU_CLASS(tluis[1], 0, 0)
         action = get_command_action(context_menu, "timeline.move_down")
         assert action
         with undoable():

--- a/tests/ui/timelines/test_timelineui_collection.py
+++ b/tests/ui/timelines/test_timelineui_collection.py
@@ -295,6 +295,30 @@ class TestSeek:
         drag_mouse_in_timeline_view(target_x, y)
         assert marker_tlui.playback_line.line().x1() == target_x
 
+    def test_slider_drag_release_seeks_media(
+        self, marker_tlui, slider_tlui, tilia_state
+    ):
+        # Regression: dragging the trough used to post Post.PLAYER_SEEK on
+        # release, which had no listeners, so the media position never
+        # actually moved (only the visual playback lines did, via
+        # SLIDER_DRAG). The fix routes the release through `media.seek`.
+        y = slider_tlui.trough.pos().y()
+        click_timeline_ui(slider_tlui, 0, y=y)
+        target_x = time_x_converter.get_x_by_time(60)
+        drag_mouse_in_timeline_view(target_x, y)
+        assert tilia_state.current_time == pytest.approx(60)
+
+    def test_slider_click_seeks_media(self, marker_tlui, slider_tlui, tilia_state):
+        # Companion to the drag-release regression: the click path used
+        # `commands.execute("media.seek", ...)` already and was never
+        # broken — pin it so a future refactor can't break both at once.
+        # Click the line itself (centre y of the view), not the trough's y.
+        line_y = slider_tlui.view.height() / 2
+        target_x = time_x_converter.get_x_by_time(40)
+        click_timeline_ui(slider_tlui, 40, y=line_y)
+        assert tilia_state.current_time == pytest.approx(40)
+        assert marker_tlui.playback_line.line().x1() == pytest.approx(target_x)
+
     @pytest.mark.parametrize(
         "tlui,request_to_serve, add_request",
         [

--- a/tilia/app.py
+++ b/tilia/app.py
@@ -155,14 +155,14 @@ class App:
     def is_file_modified(self) -> bool:
         return self.file_manager.is_file_modified(self.get_app_state())
 
-    def on_open(self, path: Path | str | None = None) -> None:
+    def on_open(self, path: Path | str | None = None) -> bool:
         if isinstance(path, str):
             path = Path(path)
 
         if self.is_file_modified():
             success, should_save = get(Get.FROM_USER_SHOULD_SAVE_CHANGES)
             if not success:
-                return
+                return False
 
             if should_save:
                 commands.execute("file.save")
@@ -170,14 +170,14 @@ class App:
         if not path:
             success, path = get(Get.FROM_USER_TILIA_FILE_PATH)
             if not success:
-                return
+                return False
         prev_state = self.get_app_state()
         self.on_clear()
 
         success, file, old_path = open_tla(path)
         if not success:
             self.on_restore_state(prev_state)
-            return
+            return False
 
         self.old_file_path = old_path
         self.cur_file_path = Path(file.file_path)
@@ -187,7 +187,7 @@ class App:
         success = self.on_file_load(file)
         if not success:
             self.on_restore_state(prev_state)
-            return
+            return False
 
         file.timelines, file.timelines_hash = self.get_timelines_state()
 
@@ -203,6 +203,8 @@ class App:
         self.file_manager.file = file
         post(Post.APP_FILE_LOADED, file)
         self.update_recent_files()
+
+        return True
 
     def update_recent_files(self):
         try:

--- a/tilia/file/file_manager.py
+++ b/tilia/file/file_manager.py
@@ -244,12 +244,13 @@ class FileManager:
         post(Post.FILE_SAVED, path)
         return True
 
-    def on_save_as_request(self):
+    def on_save_as_request(self, path: str | None = None):
         """Prompts user for a path, and saves tilia file to it."""
         old_title = get(Get.MEDIA_TITLE)
-        accepted, path = get(Get.FROM_USER_SAVE_PATH_TILIA, old_title + ".tla")
-        if not accepted:
-            return False
+        if path is None:
+            accepted, path = get(Get.FROM_USER_SAVE_PATH_TILIA, old_title + ".tla")
+            if not accepted:
+                return False
 
         save_title = Path(path).stem
         try:
@@ -263,6 +264,7 @@ class FileManager:
 
             if save_title != old_title:
                 self.on_set_media_metadata_field("title", old_title)
+            return False
 
         post(Post.FILE_SAVED, path)
         return True

--- a/tilia/timelines/base/component/base.py
+++ b/tilia/timelines/base/component/base.py
@@ -72,7 +72,7 @@ class TimelineComponent:
             return getattr(self, attr)
         except AttributeError as e:
             raise GetComponentDataError(
-                "AttributeError while getting data from component."
+                "AttributeError while getting data from component. "
                 f"Does {type(self)} have a {attr} attribute?"
             ) from e
 

--- a/tilia/timelines/collection/collection.py
+++ b/tilia/timelines/collection/collection.py
@@ -154,10 +154,10 @@ class Timelines:
     def get_timelines_by_attr(self, attr: str, value: Any):
         return [tl for tl in self if getattr(tl, attr) == value]
 
-    def set_timeline_data(self, id: int, attr: str, value: Any):
+    def set_timeline_data(self, id: int, attr: str, value: Any) -> bool:
         timeline = self.get_timeline(id)
         if timeline.get_data(attr) == value:
-            return
+            return False
         value, success = self.get_timeline(id).set_data(attr, value)
         if success:
             post(Post.TIMELINE_SET_DATA_DONE, id, attr, value)

--- a/tilia/ui/color.py
+++ b/tilia/ui/color.py
@@ -1,9 +1,9 @@
 from PySide6.QtGui import QColor
 
 
-def get_tinted_color(color: str, factor: int) -> str:
+def get_tinted_color(color: str | QColor, factor: int) -> str:
     return QColor(color).darker(factor).name()
 
 
-def get_untinted_color(color: str, factor: int) -> str:
+def get_untinted_color(color: str | QColor, factor: int) -> str:
     return QColor(color).lighter(factor).name()

--- a/tilia/ui/timelines/base/context_menus.py
+++ b/tilia/ui/timelines/base/context_menus.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from tilia.requests import Get, get
 from tilia.ui import commands
 from tilia.ui.commands import CommandQAction, get_qaction
 from tilia.ui.menus import MenuItemKind, TiliaMenu
+
+if TYPE_CHECKING:
+    from tilia.ui.timelines.base.timeline import TimelineUI
 
 
 class TimelineUIContextMenu(TiliaMenu):
@@ -11,7 +18,7 @@ class TimelineUIContextMenu(TiliaMenu):
         (MenuItemKind.COMMAND, "timeline.set_height"),
     ]
 
-    def __init__(self, timeline_ui):
+    def __init__(self, timeline_ui: TimelineUI, x: int, y: int):
         super().__init__()
         self.timeline_ui = timeline_ui
         self._add_timeline_actions()

--- a/tilia/ui/timelines/base/context_menus.py
+++ b/tilia/ui/timelines/base/context_menus.py
@@ -24,8 +24,8 @@ class TimelineUIContextMenu(TiliaMenu):
         self._add_timeline_actions()
 
     def _add_timeline_actions(self):
-        self.addSeparator()
-
+        # Move up/down belong with the top "this timeline" actions
+        # (Set name, etc.) — they reorder the timeline as a whole.
         self.check_move_up()
         self.check_move_down()
         self.add_default_actions()
@@ -50,7 +50,7 @@ class TimelineUIContextMenu(TiliaMenu):
         }
         if indices_to_timelines.get(current_index - 1, False):
             move_up = CommandQAction("timeline.move_up", self)
-            move_up.setText("Move up")
+            move_up.setText("Move timeline up")
             move_up.triggered.connect(on_move_up)
             self.addAction(move_up)
 
@@ -68,7 +68,7 @@ class TimelineUIContextMenu(TiliaMenu):
         }
         if indices_to_timelines.get(current_index + 1, False):
             move_down = CommandQAction("timeline.move_down", self)
-            move_down.setText("Move down")
+            move_down.setText("Move timeline down")
             move_down.triggered.connect(on_move_down)
             self.addAction(move_down)
 

--- a/tilia/ui/timelines/base/timeline.py
+++ b/tilia/ui/timelines/base/timeline.py
@@ -483,7 +483,7 @@ class TimelineUI(ABC):  # noqa: B024
     def display_timeline_context_menu(self, x: int, y: int):
         if not self.CONTEXT_MENU_CLASS:
             return
-        self.CONTEXT_MENU_CLASS(self).exec(QPoint(x, y))
+        self.CONTEXT_MENU_CLASS(self, x, y).exec(QPoint(x, y))
 
     def on_window_open_done(self, kind: WindowKind):
         if kind != WindowKind.INSPECT:

--- a/tilia/ui/timelines/collection/collection.py
+++ b/tilia/ui/timelines/collection/collection.py
@@ -189,7 +189,7 @@ class TimelineUIs:
         commands.register(
             "timeline.set_name",
             self.on_timeline_set_name,
-            "Set name",
+            "Set timeline name",
         )
 
         commands.register(

--- a/tilia/ui/timelines/harmony/context_menu.py
+++ b/tilia/ui/timelines/harmony/context_menu.py
@@ -42,7 +42,7 @@ class HarmonyTimelineUIContextMenu(TimelineUIContextMenu):
         (MenuItemKind.COMMAND, "timeline.harmony.hide_keys"),
     ]
 
-    def __init__(self, timeline_ui):
+    def __init__(self, timeline_ui, x: int, y: int):
         hide_keys_action = commands.get_qaction("timeline.harmony.hide_keys")
         show_keys_action = commands.get_qaction("timeline.harmony.show_keys")
         if timeline_ui.get_data("visible_level_count") == 1:
@@ -51,4 +51,4 @@ class HarmonyTimelineUIContextMenu(TimelineUIContextMenu):
         else:
             hide_keys_action.setVisible(True)
             show_keys_action.setVisible(False)
-        super().__init__(timeline_ui)
+        super().__init__(timeline_ui, x, y)

--- a/tilia/ui/timelines/score/context_menu.py
+++ b/tilia/ui/timelines/score/context_menu.py
@@ -1,5 +1,8 @@
 from tilia.ui.menus import MenuItemKind
-from tilia.ui.timelines.base.context_menus import TimelineUIElementContextMenu
+from tilia.ui.timelines.base.context_menus import (
+    TimelineUIElementContextMenu,
+    TimelineUIContextMenu,
+)
 
 
 class NoteContextMenu(TimelineUIElementContextMenu):
@@ -12,6 +15,6 @@ class NoteContextMenu(TimelineUIElementContextMenu):
     ]
 
 
-class ScoreTimelineUIContextMenu(TimelineUIElementContextMenu):
-    name = "Beat timeline"
-    items = [(MenuItemKind, "timeline.set_name")]
+class ScoreTimelineUIContextMenu(TimelineUIContextMenu):
+    name = "Score timeline"
+    items = [(MenuItemKind.COMMAND, "timeline.set_name")]

--- a/tilia/ui/timelines/score/context_menu.py
+++ b/tilia/ui/timelines/score/context_menu.py
@@ -1,7 +1,7 @@
 from tilia.ui.menus import MenuItemKind
 from tilia.ui.timelines.base.context_menus import (
-    TimelineUIElementContextMenu,
     TimelineUIContextMenu,
+    TimelineUIElementContextMenu,
 )
 
 

--- a/tilia/ui/timelines/view.py
+++ b/tilia/ui/timelines/view.py
@@ -65,12 +65,18 @@ class TimelineView(QGraphicsView):
             )
 
         def handle_right_click():
+            items = [
+                item
+                for item in self.items(event.pos())
+                if not getattr(item, "ignore_right_click", False)
+            ]
+            item = items[0] if items else None
             post(
                 Post.TIMELINE_VIEW_RIGHT_CLICK,
                 self,
                 self.mapToGlobal(event.pos()).x(),
                 self.mapToGlobal(event.pos()).y(),
-                self.itemAt(event.pos()),
+                item,
                 QGuiApplication.keyboardModifiers(),
                 double=False,
             )

--- a/tilia/ui/windows/inspect.py
+++ b/tilia/ui/windows/inspect.py
@@ -243,16 +243,28 @@ class Inspect(QDockWidget):
 
     @staticmethod
     def set_widget_value(widget, value):
-        if isinstance(widget, (QLineEdit, QLabel)):
-            if widget.text() != value:
-                widget.setText(value)
-        elif isinstance(widget, QTextEdit):
-            if widget.toPlainText() != value:
-                widget.setText(value)
-        elif isinstance(widget, QComboBox):
-            widget.setCurrentIndex(widget.findData(value))
-        elif isinstance(widget, QSpinBox):
-            widget.setValue(value)
+        # Block signals while writing programmatically: setText / setValue
+        # / setCurrentIndex would otherwise fire textChanged etc., which the
+        # inspector connects to its on_*_changed handlers. Those handlers
+        # post INSPECTOR_FIELD_EDITED, which the still-selected element's
+        # listener interprets as a user edit and writes back to the
+        # component — clobbering data that was just set programmatically
+        # (e.g. merging ranges, deselect cascades that re-display a stale
+        # snapshot from inspected_objects_stack).
+        widget.blockSignals(True)
+        try:
+            if isinstance(widget, (QLineEdit, QLabel)):
+                if widget.text() != value:
+                    widget.setText(value)
+            elif isinstance(widget, QTextEdit):
+                if widget.toPlainText() != value:
+                    widget.setText(value)
+            elif isinstance(widget, QComboBox):
+                widget.setCurrentIndex(widget.findData(value))
+            elif isinstance(widget, QSpinBox):
+                widget.setValue(value)
+        finally:
+            widget.blockSignals(False)
 
     def hide_or_show_field(self, field_name, value):
         if value == HIDE_FIELD:


### PR DESCRIPTION
12 commits with small fixes/improvements. Including:
- `refactor: return success from App.on_open`
- `fix: inheritance/menu-name, typing`
- `chore: take path parameter to file.save_as command`
- `chore: pass y argument to timelines context menus`
- `feat: skip QGraphicsItems with ignore_right_click=True on right click`
- `fix: rename "Set name" timeline action to "Set timeline name"`
- `chore: tidy debug print and GetComponentDataError message`
- `fix: avoid invalid-return-value error when set_timeline_data is a no-op`
- `fix: block widget signals during programmatic value updates`
- `feat: rename and relocate "Move timeline up/down"`
- `test: cover slider click + drag-release seeking media`
