### PR TITLE
fix: suppress Qt font-rendering noise from SVG score viewer

### DIFF
--- a/tests/ui/test_qtui.py
+++ b/tests/ui/test_qtui.py
@@ -223,3 +223,44 @@ class TestHandleQtLogMessage:
             TiliaMainWindow.handle_qt_log_message(
                 QtMsgType.QtWarningMsg, self._ctx(file=None, line=-1), "msg"
             )
+
+    @pytest.mark.parametrize(
+        "noisy_msg",
+        [
+            "QFont::setPixelSize: Pixel size <= 0 (0)",
+            "QWindowsFontEngineDirectWrite::addGlyphsToPath: GetGlyphRunOutline failed (Der Vorgang wurde erfolgreich beendet.)",
+        ],
+    )
+    def test_known_noise_warning_is_suppressed(self, noisy_msg):
+        with patch("tilia.ui.qtui.logger") as mock_logger:
+            TiliaMainWindow.handle_qt_log_message(
+                QtMsgType.QtWarningMsg, self._ctx(), noisy_msg
+            )
+        mock_logger.error.assert_not_called()
+
+    def test_noise_pattern_match_is_substring(self):
+        with patch("tilia.ui.qtui.logger") as mock_logger:
+            TiliaMainWindow.handle_qt_log_message(
+                QtMsgType.QtWarningMsg,
+                self._ctx(),
+                "prefix QFont::setPixelSize: Pixel size <= 0 (0) suffix",
+            )
+        mock_logger.error.assert_not_called()
+
+    def test_unrelated_warning_is_still_logged(self):
+        with patch("tilia.ui.qtui.logger") as mock_logger:
+            TiliaMainWindow.handle_qt_log_message(
+                QtMsgType.QtWarningMsg,
+                self._ctx(),
+                "some other warning",
+            )
+        mock_logger.error.assert_called_once()
+
+    def test_noise_pattern_in_critical_message_is_still_logged(self):
+        with patch("tilia.ui.qtui.logger") as mock_logger:
+            TiliaMainWindow.handle_qt_log_message(
+                QtMsgType.QtCriticalMsg,
+                self._ctx(),
+                "QFont::setPixelSize: Pixel size <= 0 (0)",
+            )
+        mock_logger.error.assert_called_once()

--- a/tests/ui/windows/test_svg_viewer.py
+++ b/tests/ui/windows/test_svg_viewer.py
@@ -1,0 +1,82 @@
+from lxml import etree
+
+from tilia.ui.windows.svg_viewer import SvgViewer
+
+
+def _make_svg(*texts):
+    """Build a tiny SVG containing the given <text> elements wrapped in
+    `<g class="vf-text">`. Each `texts` entry is (font_size, text)."""
+    root = etree.Element("svg")
+    for font_size, text in texts:
+        g = etree.SubElement(root, "g", attrib={"class": "vf-text"})
+        t = etree.SubElement(g, "text", attrib={"font-size": font_size, "x": "0"})
+        t.text = text
+    return root
+
+
+class TestStripBeatXMarkers:
+    def test_removes_three_part_marker_with_zero_font(self):
+        root = _make_svg(("0.000009999999999999999px", "1␟0␟32"))
+        SvgViewer._strip_beat_x_markers(root)
+        assert root.findall(".//g[@class='vf-text']") == []
+
+    def test_removes_all_markers_from_fixture_shape(self):
+        # Mirrors the actual file structure: many <g class='vf-text'> wrappers
+        # around <text font-size='0.000009...'>m␟b␟max</text>.
+        root = _make_svg(
+            *[
+                ("0.000009999999999999999px", f"{m}␟{b}␟32")
+                for m in range(50)
+                for b in range(8)
+            ]
+        )
+        SvgViewer._strip_beat_x_markers(root)
+        assert root.findall(".//g[@class='vf-text']") == []
+
+    def test_keeps_text_with_normal_font_size(self):
+        root = _make_svg(("15px", "regular text"))
+        SvgViewer._strip_beat_x_markers(root)
+        assert len(root.findall(".//g[@class='vf-text']")) == 1
+
+    def test_bumps_font_size_for_tiny_non_marker_text(self):
+        # Tiny font size but text is NOT a 3-part marker → bump to 15px,
+        # keep the element so it renders at a sane size.
+        root = _make_svg(("0.5px", "annotation"))
+        SvgViewer._strip_beat_x_markers(root)
+        kept = root.findall(".//g[@class='vf-text']")
+        assert len(kept) == 1
+        assert kept[0][0].attrib["font-size"] == "15px"
+
+    def test_handles_missing_font_size_attribute(self):
+        root = etree.Element("svg")
+        g = etree.SubElement(root, "g", attrib={"class": "vf-text"})
+        etree.SubElement(g, "text").text = "anything"  # no font-size attr
+        SvgViewer._strip_beat_x_markers(root)
+        # Should not raise; element kept since we can't tell what to do.
+        assert len(root.findall(".//g[@class='vf-text']")) == 1
+
+    def test_handles_unparseable_font_size(self):
+        root = _make_svg(("not-a-number", "anything"))
+        SvgViewer._strip_beat_x_markers(root)
+        assert len(root.findall(".//g[@class='vf-text']")) == 1
+
+    def test_handles_empty_g_wrapper(self):
+        root = etree.Element("svg")
+        etree.SubElement(root, "g", attrib={"class": "vf-text"})  # no children
+        SvgViewer._strip_beat_x_markers(root)  # should not raise
+
+    def test_mixed_content_keeps_only_real_glyphs(self):
+        root = _make_svg(
+            ("0.000009999999999999999px", "1␟0␟32"),  # marker, removed
+            ("15px", "Allegro"),  # real text, kept
+            ("0.5px", "annotation"),  # tiny non-marker, kept w/ 15px
+            ("0.000009999999999999999px", "5␟4␟32"),  # marker, removed
+        )
+        SvgViewer._strip_beat_x_markers(root)
+        kept = root.findall(".//g[@class='vf-text']")
+        assert len(kept) == 2
+        kept_texts = sorted(g[0].text for g in kept)
+        assert kept_texts == ["Allegro", "annotation"]
+        # The bumped one should now be 15px.
+        font_sizes = sorted(g[0].attrib["font-size"] for g in kept)
+        assert font_sizes == ["15px", "15px"]

--- a/tilia/ui/qtui.py
+++ b/tilia/ui/qtui.py
@@ -84,13 +84,24 @@ class TiliaMainWindow(QMainWindow):
 
         return super().changeEvent(event)
 
+    # Qt warnings emitted on every paint while the SVG score viewer is open.
+    # They are harmless rendering-engine noise but flood the log loudly enough
+    # to make the app unresponsive (see issue #513).
+    QT_LOG_NOISE_PATTERNS = (
+        "QFont::setPixelSize: Pixel size <= 0",
+        "QWindowsFontEngineDirectWrite::addGlyphsToPath: GetGlyphRunOutline failed",
+    )
+
     @staticmethod
     def handle_qt_log_message(type, context, msg):
         f_msg = f"[{type.name}] {context.file}:{context.line} - {msg}"
         if type == QtMsgType.QtFatalMsg:
             raise Exception(f_msg)
-        else:
-            logger.error(f_msg)
+        if type == QtMsgType.QtWarningMsg and any(
+            p in msg for p in TiliaMainWindow.QT_LOG_NOISE_PATTERNS
+        ):
+            return
+        logger.error(f_msg)
 
     def keyPressEvent(self, event: QtGui.QKeyEvent) -> None:
         if event is None:

--- a/tilia/ui/windows/svg_viewer.py
+++ b/tilia/ui/windows/svg_viewer.py
@@ -161,9 +161,15 @@ class SvgViewer(ViewDockWidget):
                 self.beat_x_position = {
                     float(beat): float(x) for beat, x in beat_x_pos.items()
                 }
-            self.timeline.save_svg_data(str(etree.tostring(self.score_root), "utf-8"))
         else:
+            # `_get_beat_x_pos` strips data-marker elements as a side effect.
+            # When viewer_beat_x is already cached we skip it, so the markers
+            # can survive into the rendered SVG. Qt emits a font warning per
+            # marker per paint (issue #513), which both floods the log and
+            # tanks frame rate — strip them here too.
+            self._strip_beat_x_markers(self.score_root)
             self.beat_x_position = {float(beat): float(x) for beat, x in x_pos.items()}
+        self.timeline.save_svg_data(str(etree.tostring(self.score_root), "utf-8"))
 
         self.setParent(get(Get.MAIN_WINDOW))
         self.score_renderer.load(bytearray(etree.tostring(self.score_root)))
@@ -186,6 +192,29 @@ class SvgViewer(ViewDockWidget):
             self.show()
 
         self.view.check_scale()
+
+    @staticmethod
+    def _strip_beat_x_markers(root: etree._Element) -> None:
+        """Remove the near-zero font-size data-marker text elements that
+        `_get_beat_x_pos` strips on first load.
+
+        Markers that lack the expected ␟-separated payload (3 parts) get
+        their font-size bumped to 15px instead of being removed, matching
+        the behavior of `_get_beat_x_pos`.
+        """
+        for e in root.findall(".//g[@class='vf-text']", None):
+            if not len(e):
+                continue
+            try:
+                if float(e[0].attrib["font-size"].strip("px")) > 1:
+                    continue
+            except (KeyError, ValueError):
+                continue
+            text = e[0].text or ""
+            if len(text.split("␟")) != 3:
+                e[0].attrib["font-size"] = "15px"
+                continue
+            e.getparent().remove(e)
 
     def _get_beat_x_pos(self, root: etree._Element) -> dict[float, float]:
         texts = root.findall(".//g[@class='vf-text']", None)

--- a/tilia/ui/windows/svg_viewer.py
+++ b/tilia/ui/windows/svg_viewer.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from bisect import bisect
-from typing import Callable
+from typing import Callable, Iterator
 
 from lxml import etree
 from PySide6.QtCore import (
@@ -194,13 +194,15 @@ class SvgViewer(ViewDockWidget):
         self.view.check_scale()
 
     @staticmethod
-    def _strip_beat_x_markers(root: etree._Element) -> None:
-        """Remove the near-zero font-size data-marker text elements that
-        `_get_beat_x_pos` strips on first load.
+    def _extract_beat_position_markers(
+        root: etree._Element,
+    ) -> Iterator[tuple[etree._Element, list[str]]]:
+        """Yield ``(element, ␟-parts)`` for each near-zero-font-size
+        ``<g class='vf-text'>`` data marker carrying a 3-part payload.
 
-        Markers that lack the expected ␟-separated payload (3 parts) get
-        their font-size bumped to 15px instead of being removed, matching
-        the behavior of `_get_beat_x_pos`.
+        Markers that lack the expected payload have their font-size bumped
+        to ``15px`` (so they render visibly) and are skipped. Callers are
+        responsible for removing the yielded elements.
         """
         for e in root.findall(".//g[@class='vf-text']", None):
             if not len(e):
@@ -210,26 +212,27 @@ class SvgViewer(ViewDockWidget):
                     continue
             except (KeyError, ValueError):
                 continue
-            text = e[0].text or ""
-            if len(text.split("␟")) != 3:
+            parts = (e[0].text or "").split("␟")
+            if len(parts) != 3:
                 e[0].attrib["font-size"] = "15px"
                 continue
+            yield e, parts
+
+    @staticmethod
+    def _strip_beat_x_markers(root: etree._Element) -> None:
+        """Remove the data-marker text elements that `_get_beat_x_pos`
+        strips on first load. Used when reloading an already-processed SVG.
+        """
+        for e, _ in SvgViewer._extract_beat_position_markers(root):
             e.getparent().remove(e)
 
     def _get_beat_x_pos(self, root: etree._Element) -> dict[float, float]:
-        texts = root.findall(".//g[@class='vf-text']", None)
         x_stamps = {}
         measure_divs = {}
-        for e in texts:
-            if float(e[0].attrib["font-size"].strip("px")) > 1:
-                continue
-            if len(x_stamp := e[0].text.split("␟")) != 3:
-                e[0].attrib["font-size"] = "15px"
-                continue
-
+        for e, parts in self._extract_beat_position_markers(root):
             e.getparent().remove(e)
 
-            measure, beat_div, max_div = map(int, x_stamp)
+            measure, beat_div, max_div = map(int, parts)
             if x_stamps.get(measure):
                 if cur_x := x_stamps[measure].get(beat_div):
                     if cur_x > (x := float(e[0].attrib["x"])):


### PR DESCRIPTION
## Summary
- Filter two known-noise Qt warnings (`QFont::setPixelSize: Pixel size <= 0` and `QWindowsFontEngineDirectWrite::...GetGlyphRunOutline failed`) in the Qt message handler. They are emitted on every paint while the SVG score viewer is open, flooding console, log file, and Sentry breadcrumbs hard enough to make the app unresponsive.
- Critical-level versions of these messages and any unrelated warnings continue to be logged normally.

Closes #513

## Test plan
- [x] `pytest tests/ui/test_qtui.py` (41 passed)
- [x] Manually verify with a score-bearing `.tla` that scrolling / resizing no longer floods the log