### PR TITLE
fix: disable clear-timeline UI when the timeline is empty (#435)

### DIFF
--- a/tests/ui/timelines/marker/test_marker_timeline_ui.py
+++ b/tests/ui/timelines/marker/test_marker_timeline_ui.py
@@ -431,6 +431,26 @@ class TestTimelineUIContextMenu:
 
         assert marker_tlui.is_empty
 
+    def test_clear_action_is_disabled_when_timeline_is_empty(
+        self, marker_tlui, tluis
+    ):
+        # #435: clearing an empty timeline is a no-op; the menu action
+        # should be disabled to make that clear to the user.
+        context_menu = self.get_context_menu(tluis)
+        clear_action = get_command_action(context_menu, "timeline.clear")
+
+        assert not clear_action.isEnabled()
+
+    def test_clear_action_is_enabled_when_timeline_has_components(
+        self, marker_tlui, tluis
+    ):
+        commands.execute("timeline.marker.add")
+
+        context_menu = self.get_context_menu(tluis)
+        clear_action = get_command_action(context_menu, "timeline.clear")
+
+        assert clear_action.isEnabled()
+
 
 class TestInspect:
     def test_open_inspect_menu(self, marker_tlui, tluis, qtui):

--- a/tests/ui/windows/test_manage_timelines.py
+++ b/tests/ui/windows/test_manage_timelines.py
@@ -164,6 +164,37 @@ class TesttimelinesChangeWhileOpen:
     # Much more could be tested here.
 
 
+class TestClearButtonEnablement:
+    """Regression tests for #435 — Clear button should be disabled when
+    the selected timeline has nothing to clear, and should react to
+    components being added or removed underneath the open window."""
+
+    def test_disabled_when_empty(self, marker_tlui):
+        with manage_timelines() as mt:
+            assert not mt.clear_button.isEnabled()
+
+    def test_enabled_when_non_empty(self, marker_tlui):
+        commands.execute("timeline.marker.add")
+        with manage_timelines() as mt:
+            assert mt.clear_button.isEnabled()
+
+    def test_updates_when_component_added_while_open(self, marker_tlui):
+        with manage_timelines() as mt:
+            assert not mt.clear_button.isEnabled()
+            commands.execute("timeline.marker.add")
+            assert mt.clear_button.isEnabled()
+
+    def test_updates_when_component_removed_while_open(
+        self, marker_tlui, tilia_state
+    ):
+        commands.execute("timeline.marker.add")
+        with manage_timelines() as mt:
+            assert mt.clear_button.isEnabled()
+            marker_tlui.select_all_elements()
+            commands.execute("timeline.component.delete")
+            assert not mt.clear_button.isEnabled()
+
+
 class TestDeleteTimeline:
     def delete_selected_timeline(self, mt):
         with patch_yes_or_no_dialog(True):

--- a/tests/ui/windows/test_manage_timelines.py
+++ b/tests/ui/windows/test_manage_timelines.py
@@ -184,9 +184,7 @@ class TestClearButtonEnablement:
             commands.execute("timeline.marker.add")
             assert mt.clear_button.isEnabled()
 
-    def test_updates_when_component_removed_while_open(
-        self, marker_tlui, tilia_state
-    ):
+    def test_updates_when_component_removed_while_open(self, marker_tlui, tilia_state):
         commands.execute("timeline.marker.add")
         with manage_timelines() as mt:
             assert mt.clear_button.isEnabled()

--- a/tests/ui/windows/test_manage_timelines.py
+++ b/tests/ui/windows/test_manage_timelines.py
@@ -164,7 +164,7 @@ class TesttimelinesChangeWhileOpen:
     # Much more could be tested here.
 
 
-class TestClearButtonEnablement:
+class TestClearButtonIsEnabled:
     """Regression tests for #435 — Clear button should be disabled when
     the selected timeline has nothing to clear, and should react to
     components being added or removed underneath the open window."""

--- a/tilia/ui/timelines/base/context_menus.py
+++ b/tilia/ui/timelines/base/context_menus.py
@@ -83,6 +83,7 @@ class TimelineUIContextMenu(TiliaMenu):
 
         clear_timeline = CommandQAction("timeline.clear", self)
         clear_timeline.setText("Clear")
+        clear_timeline.setEnabled(not self.timeline_ui.is_empty)
         clear_timeline.triggered.connect(on_clear_timeline)
         self.addAction(clear_timeline)
 

--- a/tilia/ui/windows/manage_timelines.py
+++ b/tilia/ui/windows/manage_timelines.py
@@ -32,9 +32,23 @@ class ManageTimelines(QDialog):
         self.setWindowTitle("Manage Timelines")
         self._setup_widgets()
         self._setup_checkbox()
+        self._setup_requests()
         self.show()
 
         post(Post.WINDOW_OPEN_DONE, WindowKind.MANAGE_TIMELINES)
+
+    def _setup_requests(self):
+        # Refresh the per-timeline action buttons when the selected
+        # timeline's emptiness can change underneath us (#435).
+        for post_ in (
+            Post.TIMELINE_COMPONENT_CREATED,
+            Post.TIMELINE_COMPONENT_DELETED,
+            Post.APP_STATE_RESTORE,
+        ):
+            listen(self, post_, self._refresh_buttons)
+
+    def _refresh_buttons(self, *_):
+        self.on_list_current_item_changed(self.list_widget.currentItem())
 
     def _setup_widgets(self):
         layout = QHBoxLayout()
@@ -85,7 +99,9 @@ class ManageTimelines(QDialog):
             else Qt.CheckState.Unchecked
         )
         self.delete_button.setEnabled(TimelineFlag.NOT_DELETABLE not in timeline.FLAGS)
-        self.clear_button.setEnabled(TimelineFlag.NOT_CLEARABLE not in timeline.FLAGS)
+        self.clear_button.setEnabled(
+            TimelineFlag.NOT_CLEARABLE not in timeline.FLAGS and not timeline.is_empty
+        )
 
     def on_checkbox_state_changed(self, state):
         item = self.list_widget.currentItem()


### PR DESCRIPTION
Closes #435.

## Summary

The Clear button in the Manage Timelines window and the Clear action in the timeline context menu both fired \`commands.execute(\"timeline.clear\")\`, but the underlying handler (\`Timelines.on_timeline_clear\`) silently returns \`False\` on an empty timeline (\`if timeline_ui.is_empty: return False\`). The user clicked, nothing happened, no feedback. Disabling the controls makes the no-op state visible.

- **Manage Timelines window** (\`tilia/ui/windows/manage_timelines.py\`): extend the existing \`NOT_CLEARABLE\` check on \`clear_button\` with \`not timeline.is_empty\`. The window now listens to \`TIMELINE_COMPONENT_CREATED\` / \`TIMELINE_COMPONENT_DELETED\` / \`APP_STATE_RESTORE\` and refreshes the per-timeline button enablement, so the state stays current if components are added or removed underneath the open window (e.g. user creates a marker via the toolbar, or undoes a Clear).
- **Timeline context menu** (\`tilia/ui/timelines/base/context_menus.py\`): same predicate on the Clear \`QAction\`. The menu is rebuilt on every right-click, so a one-shot \`setEnabled\` is enough.

## Why listen to those three posts

\`is_empty\` for hierarchy/beat is computed from \`len(self)\` plus a per-kind override (e.g. hierarchy ignores a single full-duration initial hierarchy). So the predicate flips on:

- component create → \`TIMELINE_COMPONENT_CREATED\`
- component delete → \`TIMELINE_COMPONENT_DELETED\`
- undo/redo (which can re-add or wipe components without firing per-component posts) → \`APP_STATE_RESTORE\`

The dialog's existing \`closeEvent\` already calls \`stop_listening_to_all(self)\`, so the new listeners are torn down for free.

## Test plan

- \`TestClearButtonEnablement\` in \`tests/ui/windows/test_manage_timelines.py\` covers the four obvious cases: empty/non-empty initial, plus component create/delete underneath the open window.
- \`TestTimelineUIContextMenu\` in \`tests/ui/timelines/marker/test_marker_timeline_ui.py\` adds two cases for the context-menu action (disabled when empty, enabled with components).
- Targeted test runs (\`tests/file/ tests/ui/windows/ tests/ui/timelines/\`) pass: 483 passed, 1 skipped, 2 xfailed, 2 xpassed.