### PR TITLE
fix: post FILE_MEDIA_DURATION_CHANGED before scale/crop (#496)

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -304,6 +304,30 @@ class TestScaleCropTimeline:
         assert len(marker_tlui) == 1
         assert marker_tlui[0].get_data("time") == 10
 
+    def test_crop_repositions_hierarchy_against_new_duration(
+        self, hierarchy_tlui, tilia_state
+    ):
+        # Regression test for #496: when on_media_duration_changed
+        # cropped components, FILE_MEDIA_DURATION_CHANGED was posted
+        # afterwards, so update_position used the *old* media_duration
+        # in time_x_converter. A hierarchy cropped to fill the new
+        # (shorter) timeline ended up drawn against the old end-time
+        # and stopped halfway across the visible area.
+        from tilia.ui.coords import time_x_converter
+        from tilia.ui.timelines.hierarchy.element import HierarchyUI
+
+        tilia_state.set_duration(100)
+        hierarchy_tlui.create_hierarchy(0, 100, 1)
+        tilia_state.set_duration(50, scale_timelines="no")  # falls back to crop
+
+        # After crop the component spans [0, 50]; the new media is 50s
+        # long so the body's right edge must align with x(50) — minus
+        # the small X_OFFSET the body adds — i.e. the timeline's right
+        # margin under the *new* converter.
+        body_right = hierarchy_tlui[0].body.rect().right()
+        expected_right = time_x_converter.get_x_by_time(50) - HierarchyUI.X_OFFSET
+        assert body_right == pytest.approx(expected_right)
+
 
 class TestFileSetup:
     def test_slider_timeline_is_created_when_loaded_file_does_not_have_one(

--- a/tilia/app.py
+++ b/tilia/app.py
@@ -126,8 +126,13 @@ class App:
     ) -> None:
         if scale_timelines:
             self.should_scale_timelines = scale_timelines
-        self.on_media_duration_changed(duration)
+        # Post the new duration first so time_x_converter (and other
+        # coordinate listeners) update before on_media_duration_changed
+        # crops or scales components — otherwise the UI re-positions
+        # cropped elements against the OLD media_duration and the
+        # timeline appears to stop at the old end-time (#496).
         post(Post.FILE_MEDIA_DURATION_CHANGED, duration)
+        self.on_media_duration_changed(duration)
 
     def is_file_modified(self) -> bool:
         return self.file_manager.is_file_modified(self.get_app_state())


### PR DESCRIPTION
Closes #496.

## Summary

\`App.set_file_media_duration\` called \`on_media_duration_changed\` first and posted \`FILE_MEDIA_DURATION_CHANGED\` afterwards. The pre-fix order meant that when the user picked **No scale → Yes crop** on a media swap to a shorter file, the crop path triggered \`update_position\` on each cropped element while \`time_x_converter.media_duration\` was still the *old* value. Components were redrawn against the wrong scale, so a hierarchy that spans the full new duration ended **halfway across the visible area** (the screenshot in the bug).

## Fix

Swap the order so listeners (\`time_x_converter\`, \`ui.coords\`, \`ui.player\`, \`file_manager.on_player_duration_changed\`) see the new duration *before* \`on_media_duration_changed\` runs the scale/crop. The scale-factor calculation inside \`on_media_duration_changed\` still reads \`self.duration\` (the previous app-level value, set at the bottom of that method), so the prompt logic and the scale factor are unaffected.

## Test plan

- New regression test \`TestScaleCropTimeline::test_crop_repositions_hierarchy_against_new_duration\`:
  - sets duration to 100, creates a hierarchy spanning [0, 100],
  - sets duration to 50 with \`scale_timelines=\"no\"\` (which falls through to crop),
  - asserts the body's right edge lines up with \`time_x_converter.get_x_by_time(50) - HierarchyUI.X_OFFSET\` — i.e. the new right margin.
- Verified that the test fails on \`origin/dev\` (body right ≈ 799, expected ≈ 1499) and passes after the fix.
- \`tests/test_app.py\` (64 passed, 1 unrelated sentry test deselected), \`tests/timelines/\` + hierarchy/marker/collection UI suites (401 passed, 2 xfailed, 2 xpassed) — no regressions.

## Note for the reviewer

The post is unconditional; before the fix it only ran *after* \`on_media_duration_changed\` returned, so there's a tiny behavioural difference for callers that pass \`should_scale_timelines\` but don't actually change the duration. \`on_media_duration_changed\` short-circuits in that case (\`if duration != self.duration\`), and downstream listeners are idempotent on same-value updates, so this should be safe.