### PR TITLE
fix: validate pre-start / post-end length on add (#495)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -80,7 +80,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        coverage run -m pytest -vs --reruns=2
+        coverage run -m pytest -vs --reruns=2 --timeout=10
 
 
     - name: Generate Coverage Report

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip wheel
-        pip install -e . --group testing --group ci-tests
+        pip install -e . --group ci-tests
 
     - name: List installed packages
       run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -80,7 +80,8 @@ jobs:
 
     - name: Test with pytest
       run: |
-        coverage run -m pytest -v -s
+        coverage run -m pytest -vs --reruns=2
+
 
     - name: Generate Coverage Report
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,3 @@ tilia/dev
 
 # uv can be useful to create worktrees
 uv.lock
-
-# AI
-CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+TiLiA (TimeLine Annotator) is a PySide6 desktop GUI for creating and visualizing timeline-based annotations over audio/video/PDF. Python 3.10–3.12 (3.13 is flaky due to PySide dependencies).
+
+## Environment
+
+A virtual environment exists at `.venv`. Activate it before running any Python command (per `.windsurf/rules/virtualenv.md`).
+
+## Common commands
+
+```bash
+# Install (editable) with dev extras and pre-commit hooks
+pip install -e .
+pip install --group dev
+pre-commit install
+
+# Run the app
+tilia                       # Qt GUI
+tilia --user-interface cli  # CLI (source-only, not in compiled builds)
+
+# Tests (pytest-env auto-sets ENVIRONMENT=test and QT_QPA_PLATFORM=offscreen)
+pytest                                                  # full suite
+pytest tests/ui/timelines/marker/test_marker_timeline_ui.py    # one file
+pytest tests/ui/timelines/marker/test_marker_timeline_ui.py::TestCreateDelete::test_create_at_selected_time  # one test
+pytest -k marker                                        # by keyword
+coverage run -m pytest && coverage report -m            # coverage
+
+# Lint / format (black + ruff; run automatically via pre-commit)
+ruff check
+black .
+
+# Build a standalone executable with Nuitka
+pip install -e . --group build
+python scripts/deploy.py <ref_name> <os_type>  # output in build/<os_type>/exe
+```
+
+Default pytest timeout is 10s (pytest-timeout). `ffmpeg` must be on PATH for audio export/convert features.
+
+## Architecture
+
+### Entry point and wiring
+
+`tilia/__main__.py` → `tilia/boot.py::boot()` constructs the QApplication, then `setup_logic()` (builds `App` with `FileManager`, `Clipboard`, `UndoManager`, `QtAudioPlayer`), then `setup_ui()` (QtUI or CLI). The `App` class (`tilia/app.py`) owns the `Timelines` collection and coordinates file ops, media, undo, clipboard.
+
+### Backend ↔ frontend split
+
+Each timeline kind has **two parallel packages**: backend model under `tilia/timelines/<kind>/` and UI view under `tilia/ui/timelines/<kind>/`. Kinds are registered in `tilia/timelines/timeline_kinds.py` (`TimelineKind` enum: audiowave, beat, harmony, hierarchy, marker, pdf, score, slider; `range` is currently being added — see `.todo.md`). The UI side mirrors the backend structure closely; when adding or modifying a timeline, expect to touch both trees plus corresponding tests under `tests/timelines/<kind>/` and `tests/ui/timelines/<kind>/`.
+
+### Two communication systems (do not confuse them)
+
+1. **Requests** (`tilia/requests/`): decoupled pub/sub between internal components. `Get` enum + `get()`/`serve()` for synchronous queries (including "ask the user" prompts via `Get.FROM_USER_*`); `Post` enum + `post()`/`listen()` for fire-and-forget events. Use this for component-to-component wiring.
+2. **Commands** (`tilia/ui/commands.py`): the **only** mechanism for user-initiated actions (menu items, shortcuts, toolbar buttons). Register with dotted names (`file.open`, `timeline.component.copy`) via `commands.register(name, callback, text=..., shortcut=..., icon=...)` and invoke with `commands.execute(name, ...)`. The docstring at the top of `commands.py` is authoritative on conventions.
+
+Rule of thumb: anything a user could trigger is a command; anything only the code triggers is a request.
+
+### Other key modules
+
+- `tilia/file/` — `.tla` file format (`TiliaFile` dataclass), save/load, autosave.
+- `tilia/media/` — Qt-based audio/video players; YouTube player embeds HTML/CSS in `media/player/`.
+- `tilia/parsers/` — CSV (`parsers/csv/<kind>.py`) and MusicXML (`parsers/score/musicxml.py`) import. `parsers/__init__.py::get_import_function` dispatches by `(TimelineKind, by={"time"|"measure"})`.
+- `tilia/ui/qtui.py` — `QtUI` and `TiliaMainWindow`; builds menubar, toolbars, dock widgets.
+- `tilia/ui/cli/` — click-style CLI exposing a subset of features.
+- `tilia/undo_manager.py` — app-state snapshots; `PauseUndoManager` context manager suppresses recording.
+
+## Code style
+
+- **Type hints required** in production code (`tilia/`). Annotate all function/method parameters, return types, and instance attributes whose types aren't obvious from initialization. Tests (`tests/`) do not need type hints.
+
+## Testing conventions
+
+Read `TESTING.md` first. Key points:
+
+- **Simulate users, don't call internals.** Use `commands.execute(...)` everywhere possible — including test *setup*, not just the action under test. Calling `tlui.create_marker(0)` directly is the old style; `commands.execute("timeline.marker.add")` is preferred even when it's not the thing being tested. Older tests violate this; refactors are welcome.
+- **Fixtures** in `tests/conftest.py` + per-kind `fixtures.py` files (registered via `pytest_plugins` in the root conftest). Common: `tilia_state`, `user_actions`, `marker_tlui`, `beat_tlui`, etc.
+- **Modal dialogs block execution** and cannot be driven directly. Two workarounds:
+  - Mock the Qt method (e.g. `QInputDialog.getInt`); helpers like `tests.utils.patch_file_dialog` exist.
+  - If the dialog is triggered by a `Get.FROM_USER_*` request, use `Serve(Get.FROM_USER_INT, (True, 150))` as a context manager to short-circuit it. Prefer mocking the dialog when feasible (covers more code).
+- **Menu/action presence checks**: use `get_submenu`, `get_command_action`, `get_qaction`, `get_command_names` from `tests/utils.py`. `CommandQAction` carries a `command_name` attribute that makes lookups by command possible.
+- **Context menus: test both presence AND behavior.** Instantiate the context menu class directly to check which actions are present. Then write a separate test that actually triggers each action through the menu and asserts the outcome. Don't stop at presence checks.
+- **Undo/redo: use `undoable()` for all user-initiated state changes.** Wrap the command call in `with undoable():` — this verifies the undo restores state exactly and redo returns to the post-action state. Every command that modifies state should have at least one `undoable()` test.
+- **Drag: test at integration level only.** Use `drag_mouse_in_timeline_view(x, y)` after clicking the drag target. Don't test drag callbacks directly. Cover: normal drag, drag beyond limits (clamped), drag resulting in a state change (e.g. row change for vertical drag).
+- **Keyboard navigation: simulate key presses.** Use `press_key(Qt.Key.Key_Up)` etc., not direct method calls. This exercises the full wiring from keypress event through to the outcome.
+- **Settings: write explicit tests** when behavior depends on a settings value (e.g. height, color, alpha). Change the setting, trigger the relevant action/update, assert the visual property changed. Settings reads and writes are routed to a test QSettings store via the `use_test_settings` fixture (auto-applied through `qtui`), so don't write per-test save/restore fixtures — set the values you depend on explicitly inside each test.
+- **Interact helpers**: Put per-kind click helpers in `tests/ui/timelines/<kind>/interact.py` (e.g. `click_range_ui(element, button, modifier)`). These should compute coordinates from element data (time → X, row → Y) so test bodies stay readable. Import them at the top of the test file.
+- **File layout for a new timeline kind:**
+  - `tests/ui/timelines/<kind>/test_<kind>_timeline_ui.py` — primary test file; no separate element-level file needed unless the element has genuinely complex standalone behavior.
+  - `tests/ui/timelines/<kind>/interact.py` — click/drag helpers.
+  - `tests/parsers/csv/test_<kind>_from_csv.py` — CSV parser tests (separate from UI tests).
+- Prefer end-to-end (backend-through-frontend) tests; backend-only tests are appropriate for complex pure logic but shouldn't be kept if they're coupled to implementation details.
+- **Gold reference**: `tests/ui/timelines/marker/test_marker_timeline_ui.py`. When uncertain about structure or depth, match that file.
+
+## Debugging GUI-only bugs
+
+When a bug is reported in the running app but the test suite is green, agents can't drive the desktop GUI themselves. The fallback is to instrument the suspect code path and ask the user to reproduce live:
+
+- Add `print("[FEATURE-DEBUG] ...", flush=True)` lines at the points where the data flow is unclear (e.g. inside the command handler, around `set_component_data` calls, in `Post.*` listeners that might overwrite state). Use a unique tag per investigation so the prints are easy to grep and remove.
+- Ask the user to run the exact action in TiLiA from a terminal and paste the tagged lines back. State which inspector / view / save-load step you want them to perform.
+- Once the cause is identified, remove the prints in the same commit as the fix — don't ship debug output.
+- Prefer this over speculation when tests cover the symptom but it still reproduces in the app: there's almost always a step in the live path (signal handler, focus change, dialog) that the test harness doesn't exercise.
+
+## CI
+
+`.github/workflows/run-tests.yml` runs ruff + pytest on Linux/macOS/Windows across Python 3.10–3.13 (excluding Windows+3.13). Linting is `continue-on-error: true` — ruff failures won't fail CI, but they should still be fixed. After tests, CI boots the GUI and CLI for 10s each as a smoke check.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ Default pytest timeout is 10s (pytest-timeout). `ffmpeg` must be on PATH for aud
 
 Each timeline kind has **two parallel packages**: backend model under `tilia/timelines/<kind>/` and UI view under `tilia/ui/timelines/<kind>/`. Kinds are registered in `tilia/timelines/timeline_kinds.py` (`TimelineKind` enum: audiowave, beat, harmony, hierarchy, marker, pdf, score, slider; `range` is currently being added — see `.todo.md`). The UI side mirrors the backend structure closely; when adding or modifying a timeline, expect to touch both trees plus corresponding tests under `tests/timelines/<kind>/` and `tests/ui/timelines/<kind>/`.
 
+Frontend constants and visual settings — paddings, margins, alignment options, fonts, color defaults — live under `tilia/ui/` (in the relevant UI module or as keys in `settings.py`), never under `tilia/timelines/<kind>/`. The backend is presentation-agnostic.
+
 ### Two communication systems (do not confuse them)
 
 1. **Requests** (`tilia/requests/`): decoupled pub/sub between internal components. `Get` enum + `get()`/`serve()` for synchronous queries (including "ask the user" prompts via `Get.FROM_USER_*`); `Post` enum + `post()`/`listen()` for fire-and-forget events. Use this for component-to-component wiring.
@@ -69,6 +71,14 @@ Rule of thumb: anything a user could trigger is a command; anything only the cod
 ## Code style
 
 - **Type hints required** in production code (`tilia/`). Annotate all function/method parameters, return types, and instance attributes whose types aren't obvious from initialization. Tests (`tests/`) do not need type hints.
+- **Use `ORDERING_ATTRS` / natural `__lt__`** when sorting timeline components. Each `TimelineComponent` subclass declares `ORDERING_ATTRS` (e.g. `Range = ("start", "row_id")`); `sorted(components)` already orders correctly. Adding `key=lambda c: c.start` is at best redundant and at worst hides the secondary tiebreaker.
+- **Don't `raise` for stale-UI references or internal-invariant violations** on paths reachable in production. Use `tilia.log.logger.error(...)` + early return. The default console threshold is `ERROR`; `WARNING` only surfaces under `dev.log_requests=True`, so `error` is the level that actually reaches users.
+
+## Commit hygiene
+
+Split unrelated changes into their own commits, even if they were touched while building a feature: codebase-wide refactors (`type(Foo)` → `type[Foo]`), deprecation removals, mechanical fixes (block-signal patterns), `Post.*` additions consumed elsewhere, and doc/test-pattern updates that emerged from the work belong on their own commits with explanatory messages. Reviewers want to evaluate each rationale separately.
+
+When you discover a pre-existing bug in code unrelated to the feature you're working on, prompt for opening a separate PR off `main`/`dev` rather than burying the fix in the feature branch.
 
 ## Testing conventions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ ci-tests = [
     "ruff>=0.15.0",
     "pytest-rerunfailures",
     "pytest-timeout",
+    {include-group = "testing"},
 ]
 dev = [
     "icecream>=2.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,7 @@ build = [
 ]
 ci-tests = [
     "coverage>=7.0.0",
-    "coverage-badge>=1.0.0",
     "ruff>=0.15.0",
-    "pytest-cov>=6.0.0",
     "pytest-rerunfailures",
     "pytest-timeout",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ name = "TiLiA"
 version = "0.6.0"
 description = "A GUI for creating and visualizing annotations over audio and video files."
 readme = "README.md"
+license = "GPL-3.0-or-later"
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "chardet<6.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,6 @@ env = [
     "ENVIRONMENT=test",
     "QT_QPA_PLATFORM=offscreen",
 ]
-timeout = 10
 
 [tool.ruff]
 exclude = ["tilia/dev"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ ci-tests = [
     "coverage-badge>=1.0.0",
     "ruff>=0.15.0",
     "pytest-cov>=6.0.0",
+    "pytest-rerunfailures",
     "pytest-timeout",
 ]
 dev = [

--- a/tests/ui/test_qtui.py
+++ b/tests/ui/test_qtui.py
@@ -223,3 +223,44 @@ class TestHandleQtLogMessage:
             TiliaMainWindow.handle_qt_log_message(
                 QtMsgType.QtWarningMsg, self._ctx(file=None, line=-1), "msg"
             )
+
+    @pytest.mark.parametrize(
+        "noisy_msg",
+        [
+            "QFont::setPixelSize: Pixel size <= 0 (0)",
+            "QWindowsFontEngineDirectWrite::addGlyphsToPath: GetGlyphRunOutline failed (Der Vorgang wurde erfolgreich beendet.)",
+        ],
+    )
+    def test_known_noise_warning_is_suppressed(self, noisy_msg):
+        with patch("tilia.ui.qtui.logger") as mock_logger:
+            TiliaMainWindow.handle_qt_log_message(
+                QtMsgType.QtWarningMsg, self._ctx(), noisy_msg
+            )
+        mock_logger.error.assert_not_called()
+
+    def test_noise_pattern_match_is_substring(self):
+        with patch("tilia.ui.qtui.logger") as mock_logger:
+            TiliaMainWindow.handle_qt_log_message(
+                QtMsgType.QtWarningMsg,
+                self._ctx(),
+                "prefix QFont::setPixelSize: Pixel size <= 0 (0) suffix",
+            )
+        mock_logger.error.assert_not_called()
+
+    def test_unrelated_warning_is_still_logged(self):
+        with patch("tilia.ui.qtui.logger") as mock_logger:
+            TiliaMainWindow.handle_qt_log_message(
+                QtMsgType.QtWarningMsg,
+                self._ctx(),
+                "some other warning",
+            )
+        mock_logger.error.assert_called_once()
+
+    def test_noise_pattern_in_critical_message_is_still_logged(self):
+        with patch("tilia.ui.qtui.logger") as mock_logger:
+            TiliaMainWindow.handle_qt_log_message(
+                QtMsgType.QtCriticalMsg,
+                self._ctx(),
+                "QFont::setPixelSize: Pixel size <= 0 (0)",
+            )
+        mock_logger.error.assert_called_once()

--- a/tests/ui/timelines/hierarchy/test_hierarchy_timeline_ui.py
+++ b/tests/ui/timelines/hierarchy/test_hierarchy_timeline_ui.py
@@ -131,6 +131,58 @@ class TestActions:
         assert tlui[0].get_data("post_end") != tlui[0].get_data("end")
         assert tlui[0].post_end_handle
 
+    def test_add_pre_start_negative_value_rejected(self, tlui, tilia_errors):
+        # #495: a negative pre-start length pushed pre_start past start,
+        # which validate_time accepts because it only checks >= 0.
+        tlui.create_hierarchy(0.1, 1, 1)
+        tlui.select_element(tlui[0])
+
+        with Serve(Get.FROM_USER_FLOAT, (True, -0.1)):
+            commands.execute("timeline.hierarchy.add_pre_start")
+
+        assert tlui[0].get_data("pre_start") == tlui[0].get_data("start")
+        tilia_errors.assert_in_error_title("Add pre-start")
+
+    def test_add_pre_start_value_exceeding_start_rejected(self, tlui, tilia_errors):
+        # #495: a pre-start length larger than the hierarchy's start
+        # pushed pre_start below the media start (validate_time rejected
+        # silently, leaving pre_start unset with no user feedback).
+        tlui.create_hierarchy(0.1, 1, 1)
+        tlui.select_element(tlui[0])
+
+        with Serve(Get.FROM_USER_FLOAT, (True, 0.5)):
+            commands.execute("timeline.hierarchy.add_pre_start")
+
+        assert tlui[0].get_data("pre_start") == tlui[0].get_data("start")
+        tilia_errors.assert_in_error_title("Add pre-start")
+
+    def test_add_post_end_negative_value_rejected(self, tlui, tilia_errors):
+        # #495: a negative post-end length silently shrank the hierarchy
+        # because post_end = end + value falls below end.
+        tlui.create_hierarchy(0, 0.5, 1)
+        tlui.select_element(tlui[0])
+
+        with Serve(Get.FROM_USER_FLOAT, (True, -0.1)):
+            commands.execute("timeline.hierarchy.add_post_end")
+
+        assert tlui[0].get_data("post_end") == tlui[0].get_data("end")
+        tilia_errors.assert_in_error_title("Add post-end")
+
+    def test_add_post_end_value_exceeding_media_duration_rejected(
+        self, tlui, tilia_state, tilia_errors
+    ):
+        # #495: a post-end pushed beyond media_duration was silently
+        # accepted (validate_time only checks >= 0).
+        tilia_state.duration = 100
+        tlui.create_hierarchy(0, 50, 1)
+        tlui.select_element(tlui[0])
+
+        with Serve(Get.FROM_USER_FLOAT, (True, 60)):  # 50 + 60 > 100
+            commands.execute("timeline.hierarchy.add_post_end")
+
+        assert tlui[0].get_data("post_end") == tlui[0].get_data("end")
+        tilia_errors.assert_in_error_title("Add post-end")
+
     def test_split(self, tlui, tilia_state):
         tlui.create_hierarchy(0, 1, 1)
         assert len(tlui) == 1

--- a/tests/ui/windows/test_svg_viewer.py
+++ b/tests/ui/windows/test_svg_viewer.py
@@ -1,0 +1,82 @@
+from lxml import etree
+
+from tilia.ui.windows.svg_viewer import SvgViewer
+
+
+def _make_svg(*texts):
+    """Build a tiny SVG containing the given <text> elements wrapped in
+    `<g class="vf-text">`. Each `texts` entry is (font_size, text)."""
+    root = etree.Element("svg")
+    for font_size, text in texts:
+        g = etree.SubElement(root, "g", attrib={"class": "vf-text"})
+        t = etree.SubElement(g, "text", attrib={"font-size": font_size, "x": "0"})
+        t.text = text
+    return root
+
+
+class TestStripBeatXMarkers:
+    def test_removes_three_part_marker_with_zero_font(self):
+        root = _make_svg(("0.000009999999999999999px", "1␟0␟32"))
+        SvgViewer._strip_beat_x_markers(root)
+        assert root.findall(".//g[@class='vf-text']") == []
+
+    def test_removes_all_markers_from_fixture_shape(self):
+        # Mirrors the actual file structure: many <g class='vf-text'> wrappers
+        # around <text font-size='0.000009...'>m␟b␟max</text>.
+        root = _make_svg(
+            *[
+                ("0.000009999999999999999px", f"{m}␟{b}␟32")
+                for m in range(50)
+                for b in range(8)
+            ]
+        )
+        SvgViewer._strip_beat_x_markers(root)
+        assert root.findall(".//g[@class='vf-text']") == []
+
+    def test_keeps_text_with_normal_font_size(self):
+        root = _make_svg(("15px", "regular text"))
+        SvgViewer._strip_beat_x_markers(root)
+        assert len(root.findall(".//g[@class='vf-text']")) == 1
+
+    def test_bumps_font_size_for_tiny_non_marker_text(self):
+        # Tiny font size but text is NOT a 3-part marker → bump to 15px,
+        # keep the element so it renders at a sane size.
+        root = _make_svg(("0.5px", "annotation"))
+        SvgViewer._strip_beat_x_markers(root)
+        kept = root.findall(".//g[@class='vf-text']")
+        assert len(kept) == 1
+        assert kept[0][0].attrib["font-size"] == "15px"
+
+    def test_handles_missing_font_size_attribute(self):
+        root = etree.Element("svg")
+        g = etree.SubElement(root, "g", attrib={"class": "vf-text"})
+        etree.SubElement(g, "text").text = "anything"  # no font-size attr
+        SvgViewer._strip_beat_x_markers(root)
+        # Should not raise; element kept since we can't tell what to do.
+        assert len(root.findall(".//g[@class='vf-text']")) == 1
+
+    def test_handles_unparseable_font_size(self):
+        root = _make_svg(("not-a-number", "anything"))
+        SvgViewer._strip_beat_x_markers(root)
+        assert len(root.findall(".//g[@class='vf-text']")) == 1
+
+    def test_handles_empty_g_wrapper(self):
+        root = etree.Element("svg")
+        etree.SubElement(root, "g", attrib={"class": "vf-text"})  # no children
+        SvgViewer._strip_beat_x_markers(root)  # should not raise
+
+    def test_mixed_content_keeps_only_real_glyphs(self):
+        root = _make_svg(
+            ("0.000009999999999999999px", "1␟0␟32"),  # marker, removed
+            ("15px", "Allegro"),  # real text, kept
+            ("0.5px", "annotation"),  # tiny non-marker, kept w/ 15px
+            ("0.000009999999999999999px", "5␟4␟32"),  # marker, removed
+        )
+        SvgViewer._strip_beat_x_markers(root)
+        kept = root.findall(".//g[@class='vf-text']")
+        assert len(kept) == 2
+        kept_texts = sorted(g[0].text for g in kept)
+        assert kept_texts == ["Allegro", "annotation"]
+        # The bumped one should now be 15px.
+        font_sizes = sorted(g[0].attrib["font-size"] for g in kept)
+        assert font_sizes == ["15px", "15px"]

--- a/tilia/errors.py
+++ b/tilia/errors.py
@@ -72,6 +72,14 @@ HIERARCHY_CHANGE_LEVEL_FAILED = Error(
 HIERARCHY_GROUP_FAILED = Error("Group hierarchies", "Grouping failed: {}")
 HIERARCHY_MERGE_FAILED = Error("Merge hierarchies", "Merge failed: {}")
 HIERARCHY_SPLIT_FAILED = Error("Split hierarchy", "Split failed: {}")
+HIERARCHY_PRE_START_INVALID = Error(
+    "Add pre-start",
+    "Pre-start length must be between 0 and {} seconds (the hierarchy's start time).",
+)
+HIERARCHY_POST_END_INVALID = Error(
+    "Add post-end",
+    "Post-end length must be between 0 and {} seconds (media duration minus the hierarchy's end time).",
+)
 COMPONENTS_COPY_ERROR = Error("Copy components error", "{}")
 COMPONENTS_LOAD_ERROR = Error(
     "Load components error",

--- a/tilia/errors.py
+++ b/tilia/errors.py
@@ -47,7 +47,7 @@ YOUTUBE_URL_INVALID = Error("Invalid YouTube URL", "{} is not a valid URL.")
 EXPORT_AUDIO_FAILED = Error("Export Audio", "{}")
 INVALID_HARMONY_INVERSION = Error(
     "Invalid harmony inversion",
-    "Can't set inversion '{}' on a letter of type '{}'. Please select a valid inversion for this letter type.",
+    "Can't set inversion '{}' on a chord of type '{}'. Please select a valid inversion for this chord type.",
 )
 ADD_MODE_FAILED = Error("Add key failed", "Adding key failed: {}.")
 ADD_HARMONY_FAILED = Error("Add harmony failed", "{}")

--- a/tilia/ui/player.py
+++ b/tilia/ui/player.py
@@ -237,8 +237,10 @@ class PlayerToolbar(QToolBar):
     def _update_stylesheet(self):
         self.volume_slider.setStyleSheet(
             "QSlider {margin-right: 4px;}"
-            "QSlider::groove:horizontal { height: 4px; background: palette(text);}"
-            "QSlider::handle::horizontal { background: palette(text); border: 2px solid palette(text); width: 8px; margin: -4px 0; border-radius: 6px;}"
+            "QSlider::groove::horizontal { height: 4px;}"
+            "QSlider::groove::horizontal:enabled { background: palette(text); }"
+            "QSlider::handle::horizontal { width: 8px; margin: -4px 0; border-radius: 6px;}"
+            "QSlider::handle::horizontal:enabled { background: palette(text); border: 2px solid palette(text); }"
         )
 
     def add_playback_rate_spinbox(self):

--- a/tilia/ui/qtui.py
+++ b/tilia/ui/qtui.py
@@ -84,13 +84,24 @@ class TiliaMainWindow(QMainWindow):
 
         return super().changeEvent(event)
 
+    # Qt warnings emitted on every paint while the SVG score viewer is open.
+    # They are harmless rendering-engine noise but flood the log loudly enough
+    # to make the app unresponsive (see issue #513).
+    QT_LOG_NOISE_PATTERNS = (
+        "QFont::setPixelSize: Pixel size <= 0",
+        "QWindowsFontEngineDirectWrite::addGlyphsToPath: GetGlyphRunOutline failed",
+    )
+
     @staticmethod
     def handle_qt_log_message(type, context, msg):
         f_msg = f"[{type.name}] {context.file}:{context.line} - {msg}"
         if type == QtMsgType.QtFatalMsg:
             raise Exception(f_msg)
-        else:
-            logger.error(f_msg)
+        if type == QtMsgType.QtWarningMsg and any(
+            p in msg for p in TiliaMainWindow.QT_LOG_NOISE_PATTERNS
+        ):
+            return
+        logger.error(f_msg)
 
     def keyPressEvent(self, event: QtGui.QKeyEvent) -> None:
         if event is None:

--- a/tilia/ui/timelines/hierarchy/timeline.py
+++ b/tilia/ui/timelines/hierarchy/timeline.py
@@ -1,3 +1,4 @@
+import tilia.errors
 import tilia.ui.strings
 import tilia.ui.timelines.copy_paste
 from tilia.requests import Get, Post, get, listen, post
@@ -351,6 +352,15 @@ class HierarchyTimelineUI(TimelineUI):
         if not accept:
             return False
 
+        # The earliest start in the selection bounds how far back the
+        # pre-start can extend; anything larger pushes pre_start before
+        # the media start, which validate_time would reject silently
+        # (#495).
+        earliest_start = min(elm.get_data("start") for elm in elements)
+        if not 0 <= value <= earliest_start:
+            tilia.errors.display(tilia.errors.HIERARCHY_PRE_START_INVALID, earliest_start)
+            return False
+
         self._on_add_frame(elements, value, HierarchyUI.Extremity.PRE_START)
         return True
 
@@ -358,6 +368,14 @@ class HierarchyTimelineUI(TimelineUI):
     def on_add_post_end(self, elements: list[HierarchyUI]):
         accept, value = get(Get.FROM_USER_FLOAT, "Add post-end", "Post-end length")
         if not accept:
+            return False
+
+        # The latest end in the selection caps the post-end; pushing
+        # past media_duration leaves a phantom region (#495).
+        latest_end = max(elm.get_data("end") for elm in elements)
+        max_value = get(Get.MEDIA_DURATION) - latest_end
+        if not 0 <= value <= max_value:
+            tilia.errors.display(tilia.errors.HIERARCHY_POST_END_INVALID, max_value)
             return False
 
         self._on_add_frame(elements, value, HierarchyUI.Extremity.POST_END)

--- a/tilia/ui/windows/svg_viewer.py
+++ b/tilia/ui/windows/svg_viewer.py
@@ -161,9 +161,15 @@ class SvgViewer(ViewDockWidget):
                 self.beat_x_position = {
                     float(beat): float(x) for beat, x in beat_x_pos.items()
                 }
-            self.timeline.save_svg_data(str(etree.tostring(self.score_root), "utf-8"))
         else:
+            # `_get_beat_x_pos` strips data-marker elements as a side effect.
+            # When viewer_beat_x is already cached we skip it, so the markers
+            # can survive into the rendered SVG. Qt emits a font warning per
+            # marker per paint (issue #513), which both floods the log and
+            # tanks frame rate — strip them here too.
+            self._strip_beat_x_markers(self.score_root)
             self.beat_x_position = {float(beat): float(x) for beat, x in x_pos.items()}
+        self.timeline.save_svg_data(str(etree.tostring(self.score_root), "utf-8"))
 
         self.setParent(get(Get.MAIN_WINDOW))
         self.score_renderer.load(bytearray(etree.tostring(self.score_root)))
@@ -186,6 +192,29 @@ class SvgViewer(ViewDockWidget):
             self.show()
 
         self.view.check_scale()
+
+    @staticmethod
+    def _strip_beat_x_markers(root: etree._Element) -> None:
+        """Remove the near-zero font-size data-marker text elements that
+        `_get_beat_x_pos` strips on first load.
+
+        Markers that lack the expected ␟-separated payload (3 parts) get
+        their font-size bumped to 15px instead of being removed, matching
+        the behavior of `_get_beat_x_pos`.
+        """
+        for e in root.findall(".//g[@class='vf-text']", None):
+            if not len(e):
+                continue
+            try:
+                if float(e[0].attrib["font-size"].strip("px")) > 1:
+                    continue
+            except (KeyError, ValueError):
+                continue
+            text = e[0].text or ""
+            if len(text.split("␟")) != 3:
+                e[0].attrib["font-size"] = "15px"
+                continue
+            e.getparent().remove(e)
 
     def _get_beat_x_pos(self, root: etree._Element) -> dict[float, float]:
         texts = root.findall(".//g[@class='vf-text']", None)

--- a/tilia/ui/windows/svg_viewer.py
+++ b/tilia/ui/windows/svg_viewer.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from bisect import bisect
-from typing import Callable
+from typing import Callable, Iterator
 
 from lxml import etree
 from PySide6.QtCore import (
@@ -194,13 +194,15 @@ class SvgViewer(ViewDockWidget):
         self.view.check_scale()
 
     @staticmethod
-    def _strip_beat_x_markers(root: etree._Element) -> None:
-        """Remove the near-zero font-size data-marker text elements that
-        `_get_beat_x_pos` strips on first load.
+    def _extract_beat_position_markers(
+        root: etree._Element,
+    ) -> Iterator[tuple[etree._Element, list[str]]]:
+        """Yield ``(element, ␟-parts)`` for each near-zero-font-size
+        ``<g class='vf-text'>`` data marker carrying a 3-part payload.
 
-        Markers that lack the expected ␟-separated payload (3 parts) get
-        their font-size bumped to 15px instead of being removed, matching
-        the behavior of `_get_beat_x_pos`.
+        Markers that lack the expected payload have their font-size bumped
+        to ``15px`` (so they render visibly) and are skipped. Callers are
+        responsible for removing the yielded elements.
         """
         for e in root.findall(".//g[@class='vf-text']", None):
             if not len(e):
@@ -210,26 +212,27 @@ class SvgViewer(ViewDockWidget):
                     continue
             except (KeyError, ValueError):
                 continue
-            text = e[0].text or ""
-            if len(text.split("␟")) != 3:
+            parts = (e[0].text or "").split("␟")
+            if len(parts) != 3:
                 e[0].attrib["font-size"] = "15px"
                 continue
+            yield e, parts
+
+    @staticmethod
+    def _strip_beat_x_markers(root: etree._Element) -> None:
+        """Remove the data-marker text elements that `_get_beat_x_pos`
+        strips on first load. Used when reloading an already-processed SVG.
+        """
+        for e, _ in SvgViewer._extract_beat_position_markers(root):
             e.getparent().remove(e)
 
     def _get_beat_x_pos(self, root: etree._Element) -> dict[float, float]:
-        texts = root.findall(".//g[@class='vf-text']", None)
         x_stamps = {}
         measure_divs = {}
-        for e in texts:
-            if float(e[0].attrib["font-size"].strip("px")) > 1:
-                continue
-            if len(x_stamp := e[0].text.split("␟")) != 3:
-                e[0].attrib["font-size"] = "15px"
-                continue
-
+        for e, parts in self._extract_beat_position_markers(root):
             e.getparent().remove(e)
 
-            measure, beat_div, max_div = map(int, x_stamp)
+            measure, beat_div, max_div = map(int, parts)
             if x_stamps.get(measure):
                 if cur_x := x_stamps[measure].get(beat_div):
                     if cur_x > (x := float(e[0].attrib["x"])):


### PR DESCRIPTION
Closes #495 (the dialog-driven half — see Out of scope below).

## Summary

\`HierarchyTimelineUI.on_add_pre_start\` / \`on_add_post_end\` accepted any \`float\` from \`FROM_USER_FLOAT\` and forwarded it to \`_on_add_frame\` without checking that the resulting time fell inside the valid range. \`Hierarchy\`'s \`validate_time\` only enforces \`>= 0\`, so all four invalid cases slipped through:

- A **negative pre-start** pushed \`pre_start\` past \`start\` (silently — \`validate_time\` accepts it).
- A **pre-start larger than start** pushed \`pre_start\` below 0; \`validate_time\` rejected, but at the component-manager level the dialog "succeeded" with no effect and no user-visible message.
- A **negative post-end** shrank the hierarchy below its \`end\`.
- A **post-end past media_duration** extended into nothing.

## Fix

Validate the input against the affected hierarchies' bounds in the add handler and surface a \`tilia.errors.display\` message naming the allowed range. When multiple hierarchies are selected, use the most restrictive bound:

- pre-start: \`min(elm.get_data(\"start\")) for elm in elements\` — the earliest start caps how far back the frame can extend before any element falls below 0.
- post-end: \`media_duration - max(elm.get_data(\"end\"))\` — symmetric.

Two new \`Error\` entries in \`tilia/errors.py\` (\`HIERARCHY_PRE_START_INVALID\`, \`HIERARCHY_POST_END_INVALID\`) interpolate the upper bound so the dialog tells the user *which* number to type.

## Test plan

Four new cases in \`tests/ui/timelines/hierarchy/test_hierarchy_timeline_ui.py::TestActions\`:

- \`test_add_pre_start_negative_value_rejected\`
- \`test_add_pre_start_value_exceeding_start_rejected\`
- \`test_add_post_end_negative_value_rejected\`
- \`test_add_post_end_value_exceeding_media_duration_rejected\`

Each asserts the hierarchy is left untouched and that \`tilia_errors\` saw an error with the right title. Hierarchy + hierarchy-UI suites stay green: 170 passed, 2 xfailed, 2 xpassed.

## Out of scope

The issue also asks about the **drag** path ("when dragging these after creation: should there be some kind of validation error instead of silently deleting them?"). Looking at \`tilia/ui/timelines/hierarchy/drag.py\`, \`get_frame_handles_drag_limits\` already clamps the drag to \`[LEFT_MARGIN_X, start_x]\` (pre-start) / \`[end_x, RIGHT_MARGIN_X]\` (post-end), so the silent-delete the issue is referring to is "user dragged the handle to coincide with start/end and the frame collapses to zero length." That's a UX call, not an invariant violation, and the wording in the issue ("should there be some kind of...") suggests the reporter wants a discussion, not a specific fix. Happy to do a follow-up if there's a concrete preference.