### PR TITLE
fix: pick a real theme when colorScheme is Unknown (#475)

### DIFF
--- a/tilia/ui/qtui.py
+++ b/tilia/ui/qtui.py
@@ -73,7 +73,7 @@ from .windows.settings import SettingsWindow
 class TiliaMainWindow(QMainWindow):
     def __init__(self):
         QIcon.setThemeSearchPaths([(Path(__file__).parent / "icons").as_posix()])
-        QIcon.setThemeName("tilia" + QApplication.styleHints().colorScheme().name)
+        QIcon.setThemeName(self._tilia_theme_name())
         super().__init__()
         self.setWindowTitle(tilia.constants.APP_NAME)
         self.setWindowIcon(QIcon.fromTheme("tilia"))
@@ -87,9 +87,18 @@ class TiliaMainWindow(QMainWindow):
 
     def changeEvent(self, event: QEvent) -> None:
         if event.type() == event.Type.ThemeChange:
-            QIcon.setThemeName("tilia" + QApplication.styleHints().colorScheme().name)
+            QIcon.setThemeName(self._tilia_theme_name())
 
         return super().changeEvent(event)
+
+    @staticmethod
+    def _tilia_theme_name() -> str:
+        # On Linux the platform may not advertise a colour preference,
+        # in which case styleHints().colorScheme() returns Unknown and
+        # we'd otherwise pick the non-existent "tiliaUnknown" theme,
+        # leaving every custom icon blank (#475).
+        scheme = QApplication.styleHints().colorScheme()
+        return "tiliaDark" if scheme == Qt.ColorScheme.Dark else "tiliaLight"
 
     # Qt warnings emitted on every paint while the SVG score viewer is open.
     # They are harmless rendering-engine noise but flood the log loudly enough


### PR DESCRIPTION
Partial fix for #475.

## Summary

\`QApplication.styleHints().colorScheme()\` returns \`Qt.ColorScheme.Unknown\` on platforms / desktop environments that don't advertise a colour preference (often minimal Linux installs without a configured GTK or Qt theme). The previous code did \`\"tilia\" + scheme.name\`, which became \`\"tiliaUnknown\"\` — a theme that doesn't exist — leaving every custom toolbar icon blank.

Map \`Unknown\` (and anything other than \`Dark\`) to \`tiliaLight\` so the custom icon set is always reachable.

## Scope

This restores the **custom** icons (\`beat-add\`, \`marker-add\`, \`hierarchy-merge\`, …) on platforms where colorScheme is Unknown. The Qt FreeDesktop-named icons used by the player toolbar (play / stop / loop / volume — \`QIcon.ThemeIcon.MediaPlaybackStart\`, \`MediaPlaylistRepeat\`, etc.) are a separate, larger problem: they're looked up in the system icon theme, and our bundled themes don't carry equivalents (no \`media-playback-start.svg\`, no \`media-playlist-repeat.svg\`). Restoring those needs SVG asset work — out of scope here. The loop case is also tracked as #478.

## Test plan

- \`tests/ui/\` suite passes: 797 passed, 9 skipped, 2 xfailed, 2 xpassed.
- I can't reproduce the empty-toolbar case on macOS; the fix is a behaviour-equivalence change for platforms where \`colorScheme\` is Light/Dark (no observable difference) and a strict improvement when it's Unknown.

A reviewer with access to a minimal Linux setup would confirm the toolbar buttons regain their custom icons (the player media buttons will still be blank — needs the SVG follow-up).