### PR TITLE
fix: reject empty beat timeline before parsing musicXML (#490)

### DIFF
--- a/tests/parsers/score/test_score_from_musicxml.py
+++ b/tests/parsers/score/test_score_from_musicxml.py
@@ -12,6 +12,22 @@ def _import_with_patch(score_tl, beat_tl, data, tmp_path):
     return errors
 
 
+def test_import_with_empty_beat_timeline(score_tl, beat_tl, tmp_path):
+    xml = """<score-partwise version="3.1">
+    <part-list>
+        <score-part id="P1"><part-name>Piano</part-name></score-part>
+    </part-list>
+    <part id="P1"><measure number="1"></measure></part>
+    </score-partwise>
+    """
+
+    success, errors = _import_with_patch(score_tl, beat_tl, xml, tmp_path)
+
+    assert not success
+    assert errors
+    assert "no beats" in errors[0].lower()
+
+
 def _get_components_by_kind(
     score_tl: ScoreTimeline, kind: ComponentKind
 ) -> list[ComponentKind]:

--- a/tests/ui/test_qtui.py
+++ b/tests/ui/test_qtui.py
@@ -65,6 +65,10 @@ class TestImport:
     def test_raises_error_if_invalid_musicXML(
         self, qtui, score_tlui, beat_tlui, tilia_errors, resources
     ):
+        beat_tlui.timeline.beat_pattern = [2]
+        for b in range(4):
+            beat_tlui.create_beat(b)
+
         with Serve(
             Get.FROM_USER_FILE_PATH,
             (

--- a/tilia/parsers/score/musicxml.py
+++ b/tilia/parsers/score/musicxml.py
@@ -490,6 +490,12 @@ def notes_from_musicXML(
 
     reader_kwargs = reader_kwargs or {}
 
+    if not beat_tl.measure_count:
+        return False, [
+            "The selected beat timeline has no beats. "
+            "Add beats to the beat timeline before importing a score."
+        ]
+
     svg_converter = musicxml_to_svg(score_tl.id)
     with TiliaMXLReader(path, file_kwargs, reader_kwargs) as file:
         parser = etree.XMLParser(remove_blank_text=True)


### PR DESCRIPTION
Closes #490.

Validates `beat_tl.measure_count` upfront in `notes_from_musicXML` and surfaces a clear "no beats" error instead of crashing deep in `get_time_by_measure`. Adds a regression test in `tests/parsers/score/test_score_from_musicxml.py`.