### PR TITLE
fix: guard SVG viewer against empty beat timeline (#491)

### DIFF
--- a/tilia/ui/windows/svg_viewer.py
+++ b/tilia/ui/windows/svg_viewer.py
@@ -449,7 +449,7 @@ class SvgViewer(ViewDockWidget):
             Get.TIMELINE_COLLECTION
         ).get_beat_timeline_for_measure_calculation()
 
-        if not beat_tl:
+        if not beat_tl or not beat_tl.measure_count:
             return {}
 
         for key, beat in beat_pos.items():


### PR DESCRIPTION
Closes #491.

The score SVG viewer crashed during `paintEvent` when the associated beat timeline was emptied after a score import — `BeatTimeline.get_time_by_measure` raises `ValueError` with no beats. Extends the existing `if not beat_tl: return {}` guard to also short-circuit when the timeline has zero measures.