### PR TITLE
fix: stop YouTube player when media is unloaded (#492)

### DIFF
--- a/tilia/media/player/youtube.py
+++ b/tilia/media/player/youtube.py
@@ -219,7 +219,10 @@ class YouTubePlayer(Player):
         self._engine_seek(0)
 
     def _engine_unload_media(self):
+        if self.is_web_page_loaded:
+            self.view.page().runJavaScript("stop()")
         self.view.hide()
+        self.video_id = None
         self.shared_object.player_toolbar_enabled = False
 
     def _engine_get_media_duration(self):


### PR DESCRIPTION
Closes #492.

`_engine_unload_media` in `YouTubePlayer` only hid the `QWebEngineView`, so the IFrame player kept running off-screen after File → New (or any other unload path). Call the existing JS `stop()` (which proxies YouTube's `stopVideo()`) before hiding, and clear `video_id` to fully reset the player object.