### PR TITLE
fix: disable player toolbar when media is unloaded (#493)

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -580,6 +580,17 @@ class TestFileNew:
         assert get(Get.MEDIA_DURATION) == 0
         assert not tilia.player.media_path
 
+    def test_player_toolbar_is_disabled(self, tilia, qtui):
+        with Serve(Get.FROM_USER_MEDIA_PATH, (True, EXAMPLE_MEDIA_PATH)):
+            commands.execute("media.load.local")
+
+        assert qtui.player_toolbar.isEnabled()
+
+        with Serve(Get.FROM_USER_SHOULD_SAVE_CHANGES, (True, False)):
+            commands.execute("file.new")
+
+        assert not qtui.player_toolbar.isEnabled()
+
     def test_all_windows_are_closed(self, tilia, qtui):
         for kind in WindowKind:
             post(Post.WINDOW_OPEN, kind)

--- a/tilia/media/player/base.py
+++ b/tilia/media/player/base.py
@@ -20,6 +20,7 @@ from tilia.requests import (
     stop_serving_all,
 )
 from tilia.ui import commands
+from tilia.ui.player import PlayerStatus
 from tilia.utils import get_tilia_class_string
 
 
@@ -141,6 +142,7 @@ class Player(ABC):
         self.is_playing = False
         self.is_looping = False
         post(Post.PLAYER_CANCEL_LOOP)
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.NO_MEDIA)
 
     def toggle_play(self, toggle_is_playing: bool):
         if toggle_is_playing:


### PR DESCRIPTION
Closes #493.

`Player.unload_media` (base) didn't post `PLAYER_UPDATE_CONTROLS NO_MEDIA`, so the toolbar stayed enabled after `on_clear` and clicking play drove the player with no source. Moves the `NO_MEDIA` post into the base so all backends behave consistently. Adds `TestFileNew::test_player_toolbar_is_disabled` regression test.