### PR TITLE
Speedier pytest

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -60,7 +60,7 @@ jobs:
     - uses: actions/cache@v5
       with:
         path: ${{ matrix.path }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
          ${{ runner.os }}-pip-
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    name: run tests
+    name: run tests (${{ matrix.python-version }}, ${{ matrix.os }})${{ matrix.suffix }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -33,6 +33,9 @@ jobs:
           path: ~/Library/Caches/pip
         - os: windows-latest
           path: ~\AppData\Local\pip\Cache
+        - os: ubuntu-latest
+          python-version: '3.11'
+          suffix: ' [with coverage]'
         exclude:
           - os: windows-latest
             python-version: '3.13' # no pyside support
@@ -70,6 +73,7 @@ jobs:
         pip install -e . --group ci-tests
 
     - name: List installed packages
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       run: |
         pip freeze
 
@@ -79,11 +83,17 @@ jobs:
       continue-on-error: true
 
     - name: Test with pytest
+      if: ${{ !(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11') }}
+      run: |
+        pytest -v --reruns=2 --timeout=10
+
+    - name: Test with pytest (coverage)
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       run: |
         coverage run -m pytest -vs --reruns=2 --timeout=10
 
-
     - name: Generate Coverage Report
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       run: |
           coverage report -m
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -81,12 +81,12 @@ jobs:
     - name: Test with pytest
       if: ${{ !(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11') }}
       run: |
-        pytest -v --reruns=2 --timeout=10
+        pytest -v -n auto --reruns=2 --timeout=10
 
     - name: Test with pytest (coverage)
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       run: |
-        coverage run -m pytest -v --reruns=2 --timeout=10
+        coverage run -m pytest -v -n auto --reruns=2 --timeout=10
 
     - name: Generate Coverage Report
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Test with pytest (coverage)
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       run: |
-        coverage run -m pytest -v -n auto --reruns=2 --timeout=10
+        pytest -v -n auto --reruns=2 --timeout=10 --cov-report= --cov=tilia
 
     - name: Generate Coverage Report
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,10 +56,6 @@ jobs:
         chmod +x ./scripts/linux-setup.sh
         ./scripts/linux-setup.sh
 
-    - name: Install timeout
-      if: runner.os == 'macOS'
-      run: brew install coreutils
-
     - uses: actions/cache@v5
       with:
         path: ${{ matrix.path }}
@@ -102,6 +98,6 @@ jobs:
       run: |
         export QT_DEBUG_PLUGINS=1
         echo "Starting GUI..."
-        timeout 10 tilia || true
+        tilia & TILIA_PID=$!; sleep 10; kill $TILIA_PID 2>/dev/null || echo "WARNING: GUI exited before 10s"; wait $TILIA_PID 2>/dev/null || true
         echo "Starting CLI..."
-        timeout 10 tilia -i=cli || true
+        tilia -i=cli & TILIA_PID=$!; sleep 10; kill $TILIA_PID 2>/dev/null || echo "WARNING: CLI exited before 10s"; wait $TILIA_PID 2>/dev/null || true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Test with pytest (coverage)
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       run: |
-        coverage run -m pytest -vs --reruns=2 --timeout=10
+        coverage run -m pytest -v --reruns=2 --timeout=10
 
     - name: Generate Coverage Report
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ ci-tests = [
     "ruff>=0.15.0",
     "pytest-rerunfailures",
     "pytest-timeout",
+    "pytest-xdist>=3.0.0",
     {include-group = "testing"},
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ build = [
 ci-tests = [
     "coverage>=7.0.0",
     "ruff>=0.15.0",
+    "pytest-cov",
     "pytest-rerunfailures",
     "pytest-timeout",
     "pytest-xdist>=3.0.0",

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -127,7 +127,12 @@ class TestExportJSON:
 
     @parametrize_component
     def test_exported_component_attributes_values_are_correct(
-        self, tilia, comp, tmp_path, request
+        self,
+        tilia,
+        comp,
+        tmp_path,
+        request,
+        tluis,  # tluis ensures qtui is listening before getfixturevalue triggers timeline creation
     ):
         comp = request.getfixturevalue(comp)
         if TimelineFlag.NOT_EXPORTABLE in comp.timeline.FLAGS:


### PR DESCRIPTION
somewhat ironically, this is probably one of the longest pytest runs. this doesn't solve issues with the speed of acquiring the runner image, but the actual speed of running the actual test suite is signifcantly improved.

we might want to consider moving the `pytest-xdist` requirement into the testing group and updating the testing docs to always run tests in parallel.