### PR TITLE
fix: set up qtmsg logger earlier

### DIFF
--- a/tests/ui/test_qtui.py
+++ b/tests/ui/test_qtui.py
@@ -8,10 +8,11 @@ from tests.conftest import parametrize_tlui
 from tests.constants import EXAMPLE_MEDIA_PATH
 from tests.mock import PatchPost, Serve
 from tests.utils import get_actions_in_menu, get_main_window_menu
+from tilia.boot import handle_qt_log_message
 from tilia.requests import Get, Post, post
 from tilia.timelines.timeline_kinds import TimelineKind
 from tilia.ui.commands import get_qaction
-from tilia.ui.qtui import FileDropEventFilter, TiliaMainWindow
+from tilia.ui.qtui import FileDropEventFilter
 from tilia.ui.timelines.marker import MarkerTimelineUI
 from tilia.ui.windows import WindowKind
 
@@ -267,13 +268,11 @@ class TestHandleQtLogMessage:
 
     def test_fatal_message_raises_exception(self):
         with pytest.raises(Exception, match=r"\[QtFatalMsg\] widget\.cpp:42 - boom"):
-            TiliaMainWindow.handle_qt_log_message(
-                QtMsgType.QtFatalMsg, self._ctx(), "boom"
-            )
+            handle_qt_log_message(QtMsgType.QtFatalMsg, self._ctx(), "boom")
 
     def test_fatal_exception_message_includes_file_and_line(self):
         with pytest.raises(Exception) as exc_info:
-            TiliaMainWindow.handle_qt_log_message(
+            handle_qt_log_message(
                 QtMsgType.QtFatalMsg, self._ctx(file="core.cpp", line=99), "fatal"
             )
         assert "core.cpp:99" in str(exc_info.value)
@@ -289,21 +288,19 @@ class TestHandleQtLogMessage:
     )
     def test_non_fatal_message_calls_logger_error(self, msg_type):
         ctx = self._ctx(file="view.cpp", line=7)
-        with patch("tilia.ui.qtui.logger") as mock_logger:
-            TiliaMainWindow.handle_qt_log_message(msg_type, ctx, "something happened")
+        with patch("tilia.boot.logger") as mock_logger:
+            handle_qt_log_message(msg_type, ctx, "something happened")
         mock_logger.error.assert_called_once_with(
             f"[{msg_type.name}] view.cpp:7 - something happened"
         )
 
     def test_non_fatal_message_does_not_raise(self):
-        with patch("tilia.ui.qtui.logger"):
-            TiliaMainWindow.handle_qt_log_message(
-                QtMsgType.QtWarningMsg, self._ctx(), "non-fatal"
-            )
+        with patch("tilia.boot.logger"):
+            handle_qt_log_message(QtMsgType.QtWarningMsg, self._ctx(), "non-fatal")
 
     def test_context_file_none_does_not_raise(self):
-        with patch("tilia.ui.qtui.logger"):
-            TiliaMainWindow.handle_qt_log_message(
+        with patch("tilia.boot.logger"):
+            handle_qt_log_message(
                 QtMsgType.QtWarningMsg, self._ctx(file=None, line=-1), "msg"
             )
 
@@ -315,15 +312,13 @@ class TestHandleQtLogMessage:
         ],
     )
     def test_known_noise_warning_is_suppressed(self, noisy_msg):
-        with patch("tilia.ui.qtui.logger") as mock_logger:
-            TiliaMainWindow.handle_qt_log_message(
-                QtMsgType.QtWarningMsg, self._ctx(), noisy_msg
-            )
+        with patch("tilia.boot.logger") as mock_logger:
+            handle_qt_log_message(QtMsgType.QtWarningMsg, self._ctx(), noisy_msg)
         mock_logger.error.assert_not_called()
 
     def test_noise_pattern_match_is_substring(self):
-        with patch("tilia.ui.qtui.logger") as mock_logger:
-            TiliaMainWindow.handle_qt_log_message(
+        with patch("tilia.boot.logger") as mock_logger:
+            handle_qt_log_message(
                 QtMsgType.QtWarningMsg,
                 self._ctx(),
                 "prefix QFont::setPixelSize: Pixel size <= 0 (0) suffix",
@@ -331,8 +326,8 @@ class TestHandleQtLogMessage:
         mock_logger.error.assert_not_called()
 
     def test_unrelated_warning_is_still_logged(self):
-        with patch("tilia.ui.qtui.logger") as mock_logger:
-            TiliaMainWindow.handle_qt_log_message(
+        with patch("tilia.boot.logger") as mock_logger:
+            handle_qt_log_message(
                 QtMsgType.QtWarningMsg,
                 self._ctx(),
                 "some other warning",
@@ -340,8 +335,8 @@ class TestHandleQtLogMessage:
         mock_logger.error.assert_called_once()
 
     def test_noise_pattern_in_critical_message_is_still_logged(self):
-        with patch("tilia.ui.qtui.logger") as mock_logger:
-            TiliaMainWindow.handle_qt_log_message(
+        with patch("tilia.boot.logger") as mock_logger:
+            handle_qt_log_message(
                 QtMsgType.QtCriticalMsg,
                 self._ctx(),
                 "QFont::setPixelSize: Pixel size <= 0 (0)",

--- a/tilia/boot.py
+++ b/tilia/boot.py
@@ -5,6 +5,7 @@ import traceback
 from collections.abc import Callable
 from typing import NoReturn
 
+from PySide6.QtCore import QtMsgType, qInstallMessageHandler
 from PySide6.QtWidgets import QApplication
 
 import tilia.utils  # noqa: F401
@@ -37,6 +38,24 @@ def handle_exception(type, value, tb):
         ui.exit(1)
 
 
+# Qt warnings emitted on every paint while the SVG score viewer is open.
+# They are harmless rendering-engine noise but flood the log loudly enough
+# to make the app unresponsive (see issue #513).
+QT_LOG_NOISE_PATTERNS = (
+    "QFont::setPixelSize: Pixel size <= 0",
+    "QWindowsFontEngineDirectWrite::addGlyphsToPath: GetGlyphRunOutline failed",
+)
+
+
+def handle_qt_log_message(type, context, msg):
+    f_msg = f"[{type.name}] {context.file}:{context.line} - {msg}"
+    if type == QtMsgType.QtFatalMsg:
+        raise Exception(f_msg)
+    if type == QtMsgType.QtWarningMsg and any(p in msg for p in QT_LOG_NOISE_PATTERNS):
+        return
+    logger.error(f_msg)
+
+
 def boot():
     sys.excepthook = handle_exception
 
@@ -44,6 +63,7 @@ def boot():
     setup_dirs()
     logger.setup()
     q_application = QApplication(sys.argv)
+    qInstallMessageHandler(handle_qt_log_message)
     global app, ui
     app = setup_logic()
     ui = setup_ui(q_application, args.user_interface)

--- a/tilia/ui/qtui.py
+++ b/tilia/ui/qtui.py
@@ -11,9 +11,7 @@ from PySide6.QtCore import (
     QKeyCombination,
     QObject,
     Qt,
-    QtMsgType,
     QUrl,
-    qInstallMessageHandler,
 )
 from PySide6.QtGui import QDesktopServices, QFontDatabase, QIcon, QPainter, QPixmap
 from PySide6.QtWidgets import (
@@ -38,7 +36,6 @@ import tilia.ui.dialogs.file
 import tilia.ui.timelines.constants
 from tilia.file.media_metadata import MediaMetadata
 from tilia.file.tilia_file import TiliaFile
-from tilia.log import logger
 from tilia.requests import Get, Post, get, listen, post, serve
 from tilia.settings import settings
 from tilia.timelines.timeline_kinds import TimelineKind as TlKind
@@ -79,7 +76,6 @@ class TiliaMainWindow(QMainWindow):
         self.setWindowTitle(tilia.constants.APP_NAME)
         self.setWindowIcon(QIcon.fromTheme("tilia"))
         self.setStatusTip("Main window")
-        qInstallMessageHandler(self.handle_qt_log_message)
         self.setAcceptDrops(True)
         self._drop_filter = FileDropEventFilter()
 
@@ -101,24 +97,6 @@ class TiliaMainWindow(QMainWindow):
         scheme = QApplication.styleHints().colorScheme()
         return "tiliaDark" if scheme == Qt.ColorScheme.Dark else "tiliaLight"
 
-    # Qt warnings emitted on every paint while the SVG score viewer is open.
-    # They are harmless rendering-engine noise but flood the log loudly enough
-    # to make the app unresponsive (see issue #513).
-    QT_LOG_NOISE_PATTERNS = (
-        "QFont::setPixelSize: Pixel size <= 0",
-        "QWindowsFontEngineDirectWrite::addGlyphsToPath: GetGlyphRunOutline failed",
-    )
-
-    @staticmethod
-    def handle_qt_log_message(type, context, msg):
-        f_msg = f"[{type.name}] {context.file}:{context.line} - {msg}"
-        if type == QtMsgType.QtFatalMsg:
-            raise Exception(f_msg)
-        if type == QtMsgType.QtWarningMsg and any(
-            p in msg for p in TiliaMainWindow.QT_LOG_NOISE_PATTERNS
-        ):
-            return
-        logger.error(f_msg)
 
     def keyPressEvent(self, event: QtGui.QKeyEvent) -> None:
         if event is None:


### PR DESCRIPTION
qt log messages were printed to console but not written to the log file