### PR TITLE
fix: merge keeps matching label/comments/color instead of joining duplicates

### DIFF
--- a/tests/timelines/hierarchy/test_hierarchy_timeline.py
+++ b/tests/timelines/hierarchy/test_hierarchy_timeline.py
@@ -781,3 +781,43 @@ class TestMerge:
 
         new_value = self.get_attr(hierarchy_tl[0], attr_name)
         assert new_value == "first" + hierarchy_tl.merge_separator + "second"
+
+    @pytest.mark.parametrize("attr_name", ATTRS)
+    def test_identical_values_kept_without_separator(self, hierarchy_tl, attr_name):
+        hrcs = self.create_units_to_merge(hierarchy_tl, 3)
+        for h in hrcs:
+            self.set_attr(h, attr_name, "same")
+
+        hierarchy_tl.merge(hrcs)
+
+        assert self.get_attr(hierarchy_tl[0], attr_name) == "same"
+
+    @pytest.mark.parametrize("attr_name", ATTRS)
+    def test_identical_values_with_empties_kept_without_separator(
+        self, hierarchy_tl, attr_name
+    ):
+        hrcs = self.create_units_to_merge(hierarchy_tl, 4)
+        self.set_attr(hrcs[0], attr_name, "same")
+        self.set_attr(hrcs[2], attr_name, "same")
+
+        hierarchy_tl.merge(hrcs)
+
+        assert self.get_attr(hierarchy_tl[0], attr_name) == "same"
+
+    def test_identical_colors_kept(self, hierarchy_tl):
+        hrcs = self.create_units_to_merge(hierarchy_tl, 3)
+        for h in hrcs:
+            h.set_data("color", "#aabbcc")
+
+        hierarchy_tl.merge(hrcs)
+
+        assert hierarchy_tl[0].get_data("color") == "#aabbcc"
+
+    def test_differing_colors_not_set(self, hierarchy_tl):
+        hrcs = self.create_units_to_merge(hierarchy_tl, 2)
+        hrcs[0].set_data("color", "#aabbcc")
+        hrcs[1].set_data("color", "#ddeeff")
+
+        hierarchy_tl.merge(hrcs)
+
+        assert hierarchy_tl[0].get_data("color") == ""

--- a/tilia/timelines/hierarchy/timeline.py
+++ b/tilia/timelines/hierarchy/timeline.py
@@ -394,17 +394,23 @@ class HierarchyTLComponentManager(TimelineComponentManager):
         if not success:
             return success, reason
 
-        # preseves label and comments from merged unitst l
+        # Preserve label, comments, and color from merged units. When every
+        # non-empty value for a field matches, keep the single matching value
+        # instead of joining duplicates with the separator.
+        separator = self.timeline.merge_separator
         attr_to_new_value = {}
         for attr in ["label", "comments"]:
-            new_value = hierarchies[0].get_data(attr)
-            for unit in hierarchies[1:]:
-                if unit.get_data(attr):
-                    if new_value:
-                        new_value += self.timeline.merge_separator
-                    new_value += unit.get_data(attr)
-            if new_value:
-                attr_to_new_value[attr] = new_value
+            non_empty = [v for v in (h.get_data(attr) for h in hierarchies) if v]
+            if not non_empty:
+                continue
+            if len(set(non_empty)) == 1:
+                attr_to_new_value[attr] = non_empty[0]
+            else:
+                attr_to_new_value[attr] = separator.join(non_empty)
+
+        colors = [h.color for h in hierarchies]
+        if colors[0] and all(c == colors[0] for c in colors[1:]):
+            attr_to_new_value["color"] = colors[0]
 
         for unit in hierarchies:
             post(Post.LOOP_IGNORE_COMPONENT, self.timeline.id, unit.id)

--- a/tilia/timelines/hierarchy/timeline.py
+++ b/tilia/timelines/hierarchy/timeline.py
@@ -408,9 +408,9 @@ class HierarchyTLComponentManager(TimelineComponentManager):
             else:
                 attr_to_new_value[attr] = separator.join(non_empty)
 
-        colors = [h.color for h in hierarchies]
-        if colors[0] and all(c == colors[0] for c in colors[1:]):
-            attr_to_new_value["color"] = colors[0]
+        colors = set(h.color for h in hierarchies)
+        if len(colors) == 1:
+            attr_to_new_value["color"] = colors.pop()
 
         for unit in hierarchies:
             post(Post.LOOP_IGNORE_COMPONENT, self.timeline.id, unit.id)


### PR DESCRIPTION
## Summary
- When every merged hierarchy has the same label or comments, the merged unit adopts that single value instead of concatenating identical copies with the configured separator.
- Same rule for color: when every merged unit shares a non-empty color, the merged unit keeps it (previously color was always dropped on merge).

## Test plan
- [x] `pytest -n auto tests/timelines/hierarchy tests/ui/timelines/hierarchy` — 172 passed.
- [x] New tests cover identical-values-no-separator, mixed empties + identical non-empties, identical colors preserved, differing colors fall back to empty.