### PR TITLE
fix: validate pre-start / post-end length BEFORE add (#495)

### DIFF
--- a/tests/ui/timelines/hierarchy/test_hierarchy_timeline_ui.py
+++ b/tests/ui/timelines/hierarchy/test_hierarchy_timeline_ui.py
@@ -2,11 +2,13 @@ import pytest
 from PySide6.QtGui import QColor
 
 from tests.mock import Serve, patch_yes_or_no_dialog
+from tests.utils import get_command_names
 from tilia.requests import Get, Post, post
 from tilia.settings import settings
 from tilia.timelines.hierarchy.components import Hierarchy
 from tilia.ui import commands
 from tilia.ui.timelines.hierarchy import HierarchyUI
+from tilia.ui.timelines.hierarchy.context_menu import HierarchyContextMenu
 
 
 @pytest.fixture
@@ -186,6 +188,59 @@ class TestActions:
         commands.execute("timeline.hierarchy.create_child")
 
         assert len(tlui) == 2
+
+
+class TestAddFrameValidation:
+    """Pre-start / post-end add is offered only when a frame fits (issue #495).
+
+    Pre-start extends left of ``start`` (toward 0); post-end extends right of
+    ``end`` (toward the media duration). When there isn't room for at least the
+    minimum length, the context menu must not offer the add.
+    """
+
+    PRE_START = "timeline.hierarchy.add_pre_start"
+    POST_END = "timeline.hierarchy.add_post_end"
+
+    # Context-menu presence.
+
+    def test_pre_start_in_menu_when_room_before_start(self, tlui):
+        tlui.create_hierarchy(1, 2, 1)
+        menu = HierarchyContextMenu(tlui[0])
+        assert self.PRE_START in get_command_names(menu)
+
+    def test_pre_start_not_in_menu_when_start_at_zero(self, tlui):
+        tlui.create_hierarchy(0, 1, 1)
+        menu = HierarchyContextMenu(tlui[0])
+        assert self.PRE_START not in get_command_names(menu)
+
+    def test_post_end_in_menu_when_room_after_end(self, tlui, tilia_state):
+        tilia_state.duration = 100
+        tlui.create_hierarchy(0, 50, 1)
+        menu = HierarchyContextMenu(tlui[0])
+        assert self.POST_END in get_command_names(menu)
+
+    def test_post_end_not_in_menu_when_end_at_duration(self, tlui, tilia_state):
+        tilia_state.duration = 100
+        tlui.create_hierarchy(0, 100, 1)
+        menu = HierarchyContextMenu(tlui[0])
+        assert self.POST_END not in get_command_names(menu)
+
+    # Too little room for a valid frame: the menu must not offer the add.
+
+    def test_pre_start_not_in_menu_when_room_below_min_length(self, tlui):
+        tlui.create_hierarchy(HierarchyUI.MIN_FRAME_LENGTH / 2, 1, 1)
+        menu = HierarchyContextMenu(tlui[0])
+        assert self.PRE_START not in get_command_names(menu)
+
+    def test_post_end_not_in_menu_when_room_below_min_length(
+        self, tlui, tilia_state
+    ):
+        tilia_state.duration = 100
+        tlui.create_hierarchy(
+            0, tilia_state.duration - HierarchyUI.MIN_FRAME_LENGTH / 2, 1
+        )
+        menu = HierarchyContextMenu(tlui[0])
+        assert self.POST_END not in get_command_names(menu)
 
 
 class TestCopyPaste:

--- a/tilia/ui/timelines/hierarchy/context_menu.py
+++ b/tilia/ui/timelines/hierarchy/context_menu.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from tilia.requests import Get, get
 from tilia.ui.menus import MenuItemKind
 from tilia.ui.timelines.base.context_menus import TimelineUIElementContextMenu
 
@@ -25,12 +26,14 @@ class HierarchyContextMenu(TimelineUIElementContextMenu):
 
     def __init__(self, element):
         self.items = DEFAULT_ITEMS.copy()
-        if not element.has_pre_start:
+        if not element.has_pre_start and element.get_data("start") > 0:
             self.items.insert(
                 6, (MenuItemKind.COMMAND, "timeline.hierarchy.add_pre_start")
             )
 
-        if not element.has_post_end:
+        if not element.has_post_end and element.get_data("end") < get(
+            Get.MEDIA_DURATION
+        ):
             self.items.insert(
                 6, (MenuItemKind.COMMAND, "timeline.hierarchy.add_post_end")
             )

--- a/tilia/ui/timelines/hierarchy/context_menu.py
+++ b/tilia/ui/timelines/hierarchy/context_menu.py
@@ -26,13 +26,18 @@ class HierarchyContextMenu(TimelineUIElementContextMenu):
 
     def __init__(self, element):
         self.items = DEFAULT_ITEMS.copy()
-        if not element.has_pre_start and element.get_data("start") > 0:
+        if (
+            not element.has_pre_start
+            and element.get_data("start") >= element.MIN_FRAME_LENGTH
+        ):
             self.items.insert(
                 6, (MenuItemKind.COMMAND, "timeline.hierarchy.add_pre_start")
             )
 
-        if not element.has_post_end and element.get_data("end") < get(
-            Get.MEDIA_DURATION
+        if (
+            not element.has_post_end
+            and get(Get.MEDIA_DURATION) - element.get_data("end")
+            >= element.MIN_FRAME_LENGTH
         ):
             self.items.insert(
                 6, (MenuItemKind.COMMAND, "timeline.hierarchy.add_post_end")

--- a/tilia/ui/timelines/hierarchy/element.py
+++ b/tilia/ui/timelines/hierarchy/element.py
@@ -74,6 +74,10 @@ class HierarchyUI(TimelineUIElement):
     NAME_WHEN_UNLABELLED = "Unnamed"
     FULL_NAME_SEPARATOR = "-"
 
+    # Smallest value the float input dialog (Qt's getDouble) accepts at its
+    # default precision.
+    MIN_FRAME_LENGTH = 0.1
+
     UPDATE_TRIGGERS = [
         "start",
         "end",

--- a/tilia/ui/timelines/hierarchy/timeline.py
+++ b/tilia/ui/timelines/hierarchy/timeline.py
@@ -347,7 +347,14 @@ class HierarchyTimelineUI(TimelineUI):
 
     @with_elements
     def on_add_pre_start(self, elements: list[HierarchyUI]):
-        accept, value = get(Get.FROM_USER_FLOAT, "Add pre-start", "Pre-start length")
+        # TODO: Disable context menu option if start == 0
+        accept, value = get(
+            Get.FROM_USER_FLOAT,
+            "Add pre-start",
+            "Pre-start length",
+            minValue=0.1,
+            maxValue=min(elm.get_data("start") for elm in elements),
+        )
         if not accept:
             return False
 
@@ -356,7 +363,15 @@ class HierarchyTimelineUI(TimelineUI):
 
     @with_elements
     def on_add_post_end(self, elements: list[HierarchyUI]):
-        accept, value = get(Get.FROM_USER_FLOAT, "Add post-end", "Post-end length")
+        # TODO: Disable context menu option if end == media_duration
+        accept, value = get(
+            Get.FROM_USER_FLOAT,
+            "Add post-end",
+            "Post-end length",
+            minValue=0.1,
+            maxValue=get(Get.MEDIA_DURATION)
+            - max(elm.get_data("end") for elm in elements),
+        )
         if not accept:
             return False
 

--- a/tilia/ui/timelines/hierarchy/timeline.py
+++ b/tilia/ui/timelines/hierarchy/timeline.py
@@ -351,7 +351,7 @@ class HierarchyTimelineUI(TimelineUI):
             Get.FROM_USER_FLOAT,
             "Add pre-start",
             "Pre-start length",
-            minValue=0.1,
+            minValue=HierarchyUI.MIN_FRAME_LENGTH,
             maxValue=min(elm.get_data("start") for elm in elements),
         )
         if not accept:
@@ -366,7 +366,7 @@ class HierarchyTimelineUI(TimelineUI):
             Get.FROM_USER_FLOAT,
             "Add post-end",
             "Post-end length",
-            minValue=0.1,
+            minValue=HierarchyUI.MIN_FRAME_LENGTH,
             maxValue=get(Get.MEDIA_DURATION)
             - max(elm.get_data("end") for elm in elements),
         )

--- a/tilia/ui/timelines/hierarchy/timeline.py
+++ b/tilia/ui/timelines/hierarchy/timeline.py
@@ -347,7 +347,6 @@ class HierarchyTimelineUI(TimelineUI):
 
     @with_elements
     def on_add_pre_start(self, elements: list[HierarchyUI]):
-        # TODO: Disable context menu option if start == 0
         accept, value = get(
             Get.FROM_USER_FLOAT,
             "Add pre-start",
@@ -363,7 +362,6 @@ class HierarchyTimelineUI(TimelineUI):
 
     @with_elements
     def on_add_post_end(self, elements: list[HierarchyUI]):
-        # TODO: Disable context menu option if end == media_duration
         accept, value = get(
             Get.FROM_USER_FLOAT,
             "Add post-end",


### PR DESCRIPTION
closes #495, replaces #522.
- clamps user input to a valid range instead of validating afterwards.
- prevents silent deletes by not allowing the invalid extremity to be created in the first place.