### PR TITLE
feat: allow filenames to be passed in as sys.argv[1]

### DIFF
--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -9,18 +10,35 @@ from tilia.boot import get_initial_file, setup_parser
 
 class TestGetInitialFilePath:
     def test_get_initial_file_no_file(self):
-        assert get_initial_file("") == ""
+        assert get_initial_file("", MagicMock()) == ""
 
     def test_get_initial_file_path_does_not_exist(self):
-        assert get_initial_file("inexistent.txt") == ""
+        error = MagicMock()
+        get_initial_file("inexistent.tla", error)
+        error.assert_called_once()
 
-    def test_get_initial_file_path_path_with_non_tla_extension(self):
-        assert get_initial_file(str(Path(__file__))) == ""
+    def test_get_initial_file_path_with_non_tla_extension(self):
+        error = MagicMock()
+        get_initial_file(str(Path(__file__)), error)
+        error.assert_called_once()
 
     def test_get_initial_file_path_good_path(self, tmp_path):
         file_path = tmp_path / "test.tla"
         file_path.touch()
-        assert Path(get_initial_file(str(file_path.resolve()))) == Path(file_path)
+        error = MagicMock()
+        result = get_initial_file(str(file_path.resolve()), error)
+        assert Path(result) == Path(file_path)
+        error.assert_not_called()
+
+    @pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows-specific")
+    def test_accepts_backslash(self, tmp_path):
+        file_path = tmp_path / "test.tla"
+        file_path.touch()
+        win_path = str(file_path)  # on Windows, str(Path) uses backslashes
+        assert "\\" in win_path
+        error = MagicMock()
+        assert get_initial_file(win_path, error) == win_path
+        error.assert_not_called()
 
 
 class TestGetSetupParser:
@@ -32,18 +50,16 @@ class TestGetSetupParser:
         assert args.file == ""
         assert args.user_interface == "qt"
 
-    def test_setup_parser_custom_values(self):
-        sys.argv = [
-            "script.py",
-            "--file",
-            "input.txt",
-            "--user-interface",
-            "cli",
-        ]
+    def test_setup_parser_custom_values(self, tmp_path):
+        file_path = tmp_path / "test.tla"
+        file_path.touch()
+        posix_path = file_path.as_posix()
+
+        sys.argv = ["script.py", posix_path, "--user-interface", "cli"]
 
         args = setup_parser()
 
-        assert args.file == "input.txt"
+        assert args.file == posix_path
         assert args.user_interface == "cli"
 
     def test_setup_parser_user_interface_cli(self):
@@ -51,6 +67,7 @@ class TestGetSetupParser:
 
         args = setup_parser()
 
+        assert args.file == ""
         assert args.user_interface == "cli"
 
     def test_setup_parser_invalid_user_interface_choice(self):
@@ -58,3 +75,41 @@ class TestGetSetupParser:
 
         with pytest.raises(argparse.ArgumentError):
             setup_parser()
+
+    def test_setup_parser_file_after_interface_flag(self, tmp_path):
+        file_path = tmp_path / "test.tla"
+        file_path.touch()
+        posix_path = file_path.as_posix()
+
+        sys.argv = ["main.py", "--user-interface", "cli", posix_path]
+
+        args = setup_parser()
+
+        assert args.file == posix_path
+        assert args.user_interface == "cli"
+
+    def test_setup_parser_nonexistent_file_raises(self):
+        sys.argv = ["main.py", "nonexistent.tla"]
+
+        with pytest.raises(SystemExit):
+            setup_parser()
+
+    def test_setup_parser_wrong_extension_raises(self, tmp_path):
+        file_path = tmp_path / "test.txt"
+        file_path.touch()
+
+        sys.argv = ["main.py", file_path.as_posix()]
+
+        with pytest.raises(SystemExit):
+            setup_parser()
+
+    @pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows-specific")
+    def test_setup_parser_accepts_backslash(self, tmp_path):
+        file_path = tmp_path / "test.tla"
+        file_path.touch()
+        win_path = str(file_path)  # on Windows, str(Path) uses backslashes
+        sys.argv = ["tilia.exe", win_path]
+
+        args = setup_parser()
+
+        assert args.file == win_path

--- a/tilia/boot.py
+++ b/tilia/boot.py
@@ -2,12 +2,15 @@ import argparse
 import os
 import sys
 import traceback
+from collections.abc import Callable
+from typing import NoReturn
 
 from PySide6.QtWidgets import QApplication
 
 import tilia.utils  # noqa: F401
 from tilia.app import App
 from tilia.clipboard import Clipboard
+from tilia.constants import FILE_EXTENSION
 from tilia.dirs import setup_dirs
 from tilia.file.autosave import AutoSaver
 from tilia.file.file_manager import FileManager
@@ -56,8 +59,8 @@ def boot():
         except ImportError:
             pass
     # has to be done after ui has been created, so timelines will get displayed
-    if file := get_initial_file(args.file):
-        app.on_open(file)
+    if args.file:
+        app.on_open(args.file)
     else:
         app.setup_file()
 
@@ -65,8 +68,11 @@ def boot():
 
 
 def setup_parser():
-    parser = argparse.ArgumentParser(exit_on_error=False)
-    parser.add_argument("--file", nargs="?", default="")
+    parser = argparse.ArgumentParser(
+        exit_on_error=False, usage="%(prog)s [--user-interface {qt,cli}] [tilia_file]"
+    )
+    parser.register("type", "tilia file", lambda f: get_initial_file(f, parser.error))
+    parser.add_argument("file", type="tilia file", nargs="?", default="")
     parser.add_argument("--user-interface", "-i", choices=["qt", "cli"], default="qt")
     return parser.parse_args()
 
@@ -103,12 +109,16 @@ def setup_ui(q_application: QApplication, interface: str):
         return CLI()
 
 
-def get_initial_file(file: str):
+def get_initial_file(file: str, error: Callable[[str], NoReturn]) -> str:
     """
     Checks if a file path was passed as an argument to process.
     If it was, returns its path. Else, returns the empty string.
     """
-    if file and os.path.isfile(file) and file.endswith(".tla"):
+    f_ext = "." + FILE_EXTENSION
+    if not file:
         return file
-    else:
-        return ""
+    if not os.path.isfile(file):
+        error(f"{file} is not a valid file.")
+    if not file.lower().endswith(f_ext.lower()):
+        error(f"{file} is not a {f_ext} file.")
+    return file


### PR DESCRIPTION
closes #466
- Removes `--file` in favour of `file` as a positional argument.
- On a non-existent file or file that does not end with the tilia extension, argparser errors and exits. 