### PR TITLE
Feat/long operation feedback

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from tilia.requests import (
 from tilia.requests.get import reset as reset_get
 from tilia.requests.post import reset as reset_post
 from tilia.ui.cli.ui import CLI
+from tilia.ui.commands import reset as reset_commands
 from tilia.ui.coords import time_x_converter
 from tilia.ui.qtui import QtUI, TiliaMainWindow
 from tilia.ui.windows import WindowKind
@@ -277,6 +278,10 @@ def cleanup_requests():
 
     reset_get()
     reset_post()
+    # Without this, a later module whose tests never instantiate qtui (e.g. a
+    # bare backend fixture calling commands.execute()) would silently reuse a
+    # command bound to this module's already-torn-down TimelineUIs instance.
+    reset_commands()
 
 
 @pytest.fixture

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -206,10 +206,7 @@ class TestFileLoad:
         file_data["media_path"] = media_path
         file_data["media_metadata"]["media length"] = 101
         tmp_file.write_text(json.dumps(file_data))
-        with (
-            Serve(Get.FROM_USER_TILIA_FILE_PATH, (True, tmp_file)),
-            Serve(Get.PLAYER_CLASS, YouTubePlayer),
-        ):
+        with Serve(Get.FROM_USER_TILIA_FILE_PATH, (True, tmp_file)):
             commands.execute("file.open")
 
         assert tilia_state.is_undo_manager_cleared

--- a/tests/timelines/pdf/test_pdf_timeline.py
+++ b/tests/timelines/pdf/test_pdf_timeline.py
@@ -15,14 +15,14 @@ class TestPageTotal:
 
 
 class TestPageNumber:
-    def test_marker_page_number_default_is_next_page(self, pdf_tl):
+    def test_marker_page_number_default_is_next_page(self, pdf_tlui, pdf_tl):
         pdf_tl.page_total = 2
         commands.execute("timeline.pdf.add")
         commands.execute("media.seek", 10)
         commands.execute("timeline.pdf.add")
         assert pdf_tl[1].get_data("page_number") == 2
 
-    def test_first_marker_page_number_is_one(self, pdf_tl):
+    def test_first_marker_page_number_is_one(self, pdf_tlui, pdf_tl):
         pdf_tl.page_total = 1
         commands.execute("timeline.pdf.add")
         assert pdf_tl[0].get_data("page_number") == 1

--- a/tests/ui/test_long_operation.py
+++ b/tests/ui/test_long_operation.py
@@ -1,0 +1,66 @@
+import pytest
+
+from tilia.requests import LongOperation, Post, post
+
+
+@pytest.fixture(autouse=True)
+def drain_stack(qtui):
+    yield
+    toolbar = qtui._long_op_toolbar
+    while toolbar._stack:
+        post(Post.LONG_OPERATION, LongOperation.DONE)
+
+
+class TestLongOperationToolbar:
+    def test_toolbar_hidden_initially(self, qtui):
+        assert qtui._long_op_toolbar.isHidden()
+
+    def test_toolbar_shows_on_started(self, qtui):
+        post(Post.LONG_OPERATION, LongOperation.STARTED, "Op")
+        assert not qtui._long_op_toolbar.isHidden()
+
+    def test_toolbar_hides_after_done(self, qtui):
+        post(Post.LONG_OPERATION, LongOperation.STARTED, "Op")
+        post(Post.LONG_OPERATION, LongOperation.DONE)
+        assert qtui._long_op_toolbar.isHidden()
+
+    def test_label_text_set_on_started(self, qtui):
+        post(Post.LONG_OPERATION, LongOperation.STARTED, "Loading file")
+        assert qtui._long_op_toolbar._label.text() == "Loading file"
+
+    def test_bar_indeterminate_on_started(self, qtui):
+        post(Post.LONG_OPERATION, LongOperation.STARTED, "Op")
+        assert qtui._long_op_toolbar._bar.maximum() == 0
+
+    def test_bar_updates_on_progress(self, qtui):
+        toolbar = qtui._long_op_toolbar
+        post(Post.LONG_OPERATION, LongOperation.STARTED, "Op")
+        post(Post.LONG_OPERATION, LongOperation.PROGRESS, 5, 10)
+        assert toolbar._bar.maximum() == 10
+        assert toolbar._bar.value() == 5
+
+    def test_nested_toolbar_stays_visible_after_inner_done(self, qtui):
+        toolbar = qtui._long_op_toolbar
+        post(Post.LONG_OPERATION, LongOperation.STARTED, "Outer")
+        post(Post.LONG_OPERATION, LongOperation.STARTED, "Inner")
+        post(Post.LONG_OPERATION, LongOperation.DONE)
+        assert not toolbar.isHidden()
+
+    def test_nested_toolbar_hides_after_outer_done(self, qtui):
+        toolbar = qtui._long_op_toolbar
+        post(Post.LONG_OPERATION, LongOperation.STARTED, "Outer")
+        post(Post.LONG_OPERATION, LongOperation.STARTED, "Inner")
+        post(Post.LONG_OPERATION, LongOperation.DONE)
+        post(Post.LONG_OPERATION, LongOperation.DONE)
+        assert toolbar.isHidden()
+
+    def test_nested_restores_outer_label_after_inner_done(self, qtui):
+        toolbar = qtui._long_op_toolbar
+        post(Post.LONG_OPERATION, LongOperation.STARTED, "Outer")
+        post(Post.LONG_OPERATION, LongOperation.STARTED, "Inner")
+        post(Post.LONG_OPERATION, LongOperation.DONE)
+        assert toolbar._label.text() == "Outer"
+
+    def test_done_without_started_is_safe(self, qtui):
+        post(Post.LONG_OPERATION, LongOperation.DONE)
+        assert qtui._long_op_toolbar.isHidden()

--- a/tests/ui/test_long_operation.py
+++ b/tests/ui/test_long_operation.py
@@ -2,7 +2,8 @@ from unittest.mock import patch
 
 import pytest
 
-from tilia.requests import LongOperation, Post, post
+from tests.mock import Serve
+from tilia.requests import Get, LongOperation, Post, post
 
 
 @pytest.fixture(autouse=True)
@@ -103,3 +104,15 @@ class TestLongOperationToolbar:
         with patch("tilia.ui.long_operation.QApplication.processEvents") as mock_pe:
             post(Post.LONG_OPERATION, LongOperation.PROGRESS, 1, 50)
             assert mock_pe.call_count == 1
+
+    def test_started_avoids_process_events_for_youtube_player(self, qtui):
+        with (
+            Serve(Get.MEDIA_TYPE, "youtube"),
+            patch("tilia.ui.long_operation.QApplication.processEvents") as mock_pe,
+            patch(
+                "tilia.ui.long_operation.QCoreApplication.sendPostedEvents"
+            ) as mock_spe,
+        ):
+            post(Post.LONG_OPERATION, LongOperation.STARTED, "Op")
+            assert mock_pe.call_count == 0
+            assert mock_spe.call_count == 1

--- a/tests/ui/test_long_operation.py
+++ b/tests/ui/test_long_operation.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from tilia.requests import LongOperation, Post, post
@@ -9,6 +11,23 @@ def drain_stack(qtui):
     toolbar = qtui._long_op_toolbar
     while toolbar._stack:
         post(Post.LONG_OPERATION, LongOperation.DONE)
+
+
+class _FakeElapsedTimer:
+    """Deterministic stand-in for QElapsedTimer so throttle tests don't
+    depend on real wall-clock timing."""
+
+    def __init__(self):
+        self.elapsed_ms = 0
+
+    def start(self):
+        self.elapsed_ms = 0
+
+    def restart(self):
+        self.elapsed_ms = 0
+
+    def elapsed(self):
+        return self.elapsed_ms
 
 
 class TestLongOperationToolbar:
@@ -64,3 +83,23 @@ class TestLongOperationToolbar:
     def test_done_without_started_is_safe(self, qtui):
         post(Post.LONG_OPERATION, LongOperation.DONE)
         assert qtui._long_op_toolbar.isHidden()
+
+    def test_progress_throttles_process_events(self, qtui):
+        toolbar = qtui._long_op_toolbar
+        toolbar._progress_timer = _FakeElapsedTimer()
+        post(Post.LONG_OPERATION, LongOperation.STARTED, "Op")
+        with patch("tilia.ui.long_operation.QApplication.processEvents") as mock_pe:
+            for i in range(50):
+                post(Post.LONG_OPERATION, LongOperation.PROGRESS, i, 50)
+            assert mock_pe.call_count == 0
+            assert toolbar._bar.value() == 49
+
+    def test_progress_processes_events_after_throttle_elapses(self, qtui):
+        toolbar = qtui._long_op_toolbar
+        fake_timer = _FakeElapsedTimer()
+        toolbar._progress_timer = fake_timer
+        post(Post.LONG_OPERATION, LongOperation.STARTED, "Op")
+        fake_timer.elapsed_ms = 150
+        with patch("tilia.ui.long_operation.QApplication.processEvents") as mock_pe:
+            post(Post.LONG_OPERATION, LongOperation.PROGRESS, 1, 50)
+            assert mock_pe.call_count == 1

--- a/tilia/app.py
+++ b/tilia/app.py
@@ -15,7 +15,7 @@ from tilia.exceptions import NoReplyToRequest
 from tilia.file.file_manager import open_tla
 from tilia.file.tilia_file import TiliaFile
 from tilia.media.loader import load_media
-from tilia.requests import Get, Post, get, listen, post, serve
+from tilia.requests import Get, Post, get, listen, long_operation, post, serve
 from tilia.settings import settings
 from tilia.timelines.collection.collection import Timelines
 from tilia.timelines.slider.timeline import SliderTimeline
@@ -173,7 +173,10 @@ class App:
                 return False
         prev_state = self.get_app_state()
         self.on_clear()
+        self._do_open(path, prev_state)
 
+    @long_operation("Loading file...")
+    def _do_open(self, path: Path, prev_state: dict) -> None:
         success, file, old_path = open_tla(path)
         if not success:
             self.on_restore_state(prev_state)
@@ -267,10 +270,18 @@ class App:
             self.set_file_media_duration(0.0)
             return True
 
+        return self._do_load_media(path, record, initial_duration)
+
+    @long_operation("Loading media...")
+    def _do_load_media(
+        self,
+        path: str,
+        record: bool,
+        initial_duration: float | None,
+    ) -> bool:
         success, player = load_media(
             self.player, path, initial_duration=initial_duration
         )
-
         self.player = player
 
         if success and record:

--- a/tilia/media/loader.py
+++ b/tilia/media/loader.py
@@ -27,17 +27,27 @@ def load_media(
 
 
 def _change_player_type(player, media_type):
-    player.destroy()
-    # Flush DeferredDelete events so the old widget's C++ object is actually
-    # destroyed before the new player is created. On macOS, QWebEngineView
-    # holds exclusive CoreAudio/AVFoundation resources; if the renderer process
-    # is still alive when QMediaPlayer initialises, they deadlock.
-    # processEvents() alone doesn't flush DeferredDelete (Qt requires a full
-    # event-loop cycle), but sendPostedEvents with DeferredDelete does.
-    from PySide6.QtCore import QCoreApplication, QEvent
+    if player.MEDIA_TYPE == "youtube":
+        # QWebEngineView holds exclusive CoreAudio/AVFoundation resources; if
+        # its renderer process is still alive when QMediaPlayer initialises,
+        # they deadlock on macOS. Destroy the old player and flush
+        # DeferredDelete events so its C++ object is actually gone before the
+        # new player is constructed. processEvents() alone doesn't flush
+        # DeferredDelete (Qt requires a full event-loop cycle), but
+        # sendPostedEvents with DeferredDelete does.
+        player.destroy()
 
-    QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
-    return get(Get.PLAYER_CLASS, media_type)()
+        from PySide6.QtCore import QCoreApplication, QEvent
+
+        QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+        return get(Get.PLAYER_CLASS, media_type)()
+
+    # Construct the new player before destroying the old one: if the
+    # constructor raises, app.player stays valid. Safe because serve() keeps
+    # _servers_to_requests consistent when ownership changes.
+    new_player = get(Get.PLAYER_CLASS, media_type)()
+    player.destroy()
+    return new_player
 
 
 def get_media_type_from_path(path: str):

--- a/tilia/media/player/base.py
+++ b/tilia/media/player/base.py
@@ -272,8 +272,6 @@ class Player(ABC):
         self.unload_media()
 
     def destroy(self):
-        self.stop()
-        self.unload_media()
         stop_listening_to_all(self)
         stop_serving_all(self)
         self._engine_exit()

--- a/tilia/media/player/qtplayer.py
+++ b/tilia/media/player/qtplayer.py
@@ -125,7 +125,10 @@ class QtPlayer(Player):
         return self.player.duration() / 1000
 
     def _engine_exit(self):
-        self.player = None
+        if self.player is not None:
+            self.player.stop()
+            self.player.setSource(QUrl())
+            self.player = None
         post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.NO_MEDIA)
 
     def _engine_set_volume(self, volume: int) -> None:

--- a/tilia/requests/__init__.py
+++ b/tilia/requests/__init__.py
@@ -1,2 +1,10 @@
 from .get import Get, get, serve, server, stop_serving, stop_serving_all
-from .post import Post, listen, post, stop_listening, stop_listening_to_all
+from .post import (
+    LongOperation,
+    Post,
+    listen,
+    long_operation,
+    post,
+    stop_listening,
+    stop_listening_to_all,
+)

--- a/tilia/requests/get.py
+++ b/tilia/requests/get.py
@@ -97,6 +97,15 @@ def serve(replier: Any, request: Get, callback: Callable) -> None:
     Attaches a callback to a request.
     """
 
+    # If a different server already owns this request, remove it from that
+    # server's tracking set so stop_serving_all(old_server) won't later pop
+    # the new server's callback.
+    old_replier, _ = server(request)
+    if old_replier is not None and old_replier is not replier:
+        _servers_to_requests[old_replier].discard(request)
+        if not _servers_to_requests[old_replier]:
+            _servers_to_requests.pop(old_replier)
+
     _requests_to_callbacks[request] = callback
     if replier not in _servers_to_requests.keys():
         _servers_to_requests[replier] = set()

--- a/tilia/requests/post.py
+++ b/tilia/requests/post.py
@@ -1,9 +1,52 @@
+import functools
 import os
 import weakref
 from enum import Enum, auto
 from typing import Any, Callable
 
 from tilia.log import logger
+
+
+class LongOperation(Enum):
+    STARTED = auto()  # args: (label: str)  — bar starts indeterminate
+    PROGRESS = auto()  # args: (value: int, maximum: int)  — promotes bar to determinate
+    DONE = auto()  # args: ()
+
+
+def long_operation(label: str):
+    """Decorator that wraps a function with LongOperation STARTED/DONE posts.
+
+    Indeterminate (duration unknown) — animated bar for the full duration:
+
+        @long_operation("Loading file...")
+        def load(path): ...
+
+    Determinate (total steps known) — bar transitions to a progress bar on
+    the first PROGRESS post:
+
+        @long_operation("Creating beats...")
+        def fill(items):
+            for i, item in enumerate(items):
+                process(item)
+                post(Post.LONG_OPERATION, LongOperation.PROGRESS, i + 1, len(items))
+
+    DONE is always posted in a finally block, even if the function raises.
+    Operations may nest: each call pushes onto a stack; the toolbar stays
+    visible until the stack empties.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            post(Post.LONG_OPERATION, LongOperation.STARTED, label)
+            try:
+                return func(*args, **kwargs)
+            finally:
+                post(Post.LONG_OPERATION, LongOperation.DONE)
+
+        return wrapper
+
+    return decorator
 
 
 class Post(Enum):
@@ -32,6 +75,7 @@ class Post(Enum):
     INSPECTABLE_ELEMENT_DESELECTED = auto()
     INSPECTABLE_ELEMENT_SELECTED = auto()
     INSPECTOR_FIELD_EDITED = auto()
+    LONG_OPERATION = auto()
     LOOP_IGNORE_COMPONENT = auto()
     MEDIA_METADATA_FIELD_ADD = auto()
     MEDIA_METADATA_FIELD_SET = auto()

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -8,7 +8,7 @@ from math import isclose
 from typing import Any, cast
 
 import tilia.errors
-from tilia.requests import Get, Post, get, post
+from tilia.requests import Get, LongOperation, Post, get, long_operation, post
 from tilia.settings import settings
 from tilia.timelines.base.component.pointlike import crop_pointlike
 from tilia.timelines.base.timeline import (
@@ -654,17 +654,22 @@ class BeatTimeline(Timeline):
         BY_AMOUNT = 0
         BY_INTERVAL = 1
 
+    @long_operation("Creating beats...")
     def fill_with_beats(self, method: BeatTimeline.FillMethod, value: int | float):
         duration = get(Get.MEDIA_DURATION)
         self.component_manager.compute_is_first_in_measure = False
         # only compute at end
 
         if method == BeatTimeline.FillMethod.BY_AMOUNT:
-            for i in range(value):
+            total = int(value)
+            for i in range(total):
                 self.create_component(ComponentKind.BEAT, i * duration / value)
+                post(Post.LONG_OPERATION, LongOperation.PROGRESS, i + 1, total)
         elif method == BeatTimeline.FillMethod.BY_INTERVAL:
-            for i in range(math.floor(duration / value)):
+            total = math.floor(duration / value)
+            for i in range(total):
                 self.create_component(ComponentKind.BEAT, i * value)
+                post(Post.LONG_OPERATION, LongOperation.PROGRESS, i + 1, total)
 
         self.component_manager.compute_is_first_in_measure = True
         self.recalculate_measures()

--- a/tilia/ui/commands.py
+++ b/tilia/ui/commands.py
@@ -152,3 +152,8 @@ def _execute_prod(command_name: str, *args, **kwargs):
 
 _name_to_action = {}
 _name_to_callback = {}
+
+
+def reset() -> None:
+    _name_to_action.clear()
+    _name_to_callback.clear()

--- a/tilia/ui/long_operation.py
+++ b/tilia/ui/long_operation.py
@@ -22,15 +22,17 @@ class _DialogCursorFilter(QObject):
         self._open_count = 0
 
     def eventFilter(self, obj: QObject, event: QEvent) -> bool:
-        if isinstance(obj, QDialog):
-            if event.type() == QEvent.Type.Show:
-                if self._open_count == 0 and QApplication.overrideCursor():
-                    QApplication.restoreOverrideCursor()
-                self._open_count += 1
-            elif event.type() == QEvent.Type.Hide:
-                self._open_count = max(0, self._open_count - 1)
-                if self._open_count == 0 and self._stack:
-                    QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        if not isinstance(obj, QDialog):
+            return False
+
+        if event.type() == QEvent.Type.Show:
+            if self._open_count == 0 and QApplication.overrideCursor():
+                QApplication.restoreOverrideCursor()
+            self._open_count += 1
+        elif event.type() == QEvent.Type.Hide:
+            self._open_count = max(0, self._open_count - 1)
+            if self._open_count == 0 and self._stack:
+                QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
         return False
 
 

--- a/tilia/ui/long_operation.py
+++ b/tilia/ui/long_operation.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from PySide6.QtCore import QEvent, QObject, Qt
+from PySide6.QtCore import QElapsedTimer, QEvent, QObject, Qt
 from PySide6.QtWidgets import QApplication, QDialog, QLabel, QProgressBar, QToolBar
 
 from tilia.requests import LongOperation, Post, listen
+
+_PROGRESS_THROTTLE_MS = 100
 
 
 class _DialogCursorFilter(QObject):
@@ -69,6 +71,7 @@ class LongOperationToolbar(QToolBar):
         self.hide()
 
         self._stack: list[str] = []
+        self._progress_timer = QElapsedTimer()
         self._dialog_cursor_filter = _DialogCursorFilter(self._stack)
         self._input_block_filter = _InputBlockFilter()
         self._app: QApplication = QApplication.instance()  # type: ignore[assignment]
@@ -97,6 +100,7 @@ class LongOperationToolbar(QToolBar):
             QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
             self._app.installEventFilter(self._dialog_cursor_filter)
             self._app.installEventFilter(self._input_block_filter)
+        self._progress_timer.start()
         QApplication.processEvents()
 
     def _on_progress(self, value: int, maximum: int) -> None:
@@ -105,6 +109,9 @@ class LongOperationToolbar(QToolBar):
         if self._bar.maximum() != maximum:
             self._bar.setMaximum(maximum)
         self._bar.setValue(value)
+        if self._progress_timer.elapsed() < _PROGRESS_THROTTLE_MS:
+            return
+        self._progress_timer.restart()
         QApplication.processEvents()
 
     def _on_done(self) -> None:

--- a/tilia/ui/long_operation.py
+++ b/tilia/ui/long_operation.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from PySide6.QtCore import QElapsedTimer, QEvent, QObject, Qt
+from PySide6.QtCore import QCoreApplication, QElapsedTimer, QEvent, QObject, Qt
 from PySide6.QtWidgets import QApplication, QDialog, QLabel, QProgressBar, QToolBar
 
-from tilia.requests import LongOperation, Post, listen
+from tilia.requests import Get, LongOperation, Post, get, listen
 
 _PROGRESS_THROTTLE_MS = 100
 
@@ -95,6 +95,14 @@ class LongOperationToolbar(QToolBar):
         self._bar.setValue(0)
         self.show()
 
+    def _pump(self) -> None:
+        # See commit message for why this isn't just processEvents().
+        if get(Get.MEDIA_TYPE) == "youtube":
+            QCoreApplication.sendPostedEvents(None, QEvent.Type.LayoutRequest)
+            self.repaint()
+        else:
+            QApplication.processEvents()
+
     def _on_started(self, label: str) -> None:
         self._stack.append(label)
         self._show_current()
@@ -103,7 +111,7 @@ class LongOperationToolbar(QToolBar):
             self._app.installEventFilter(self._dialog_cursor_filter)
             self._app.installEventFilter(self._input_block_filter)
         self._progress_timer.start()
-        QApplication.processEvents()
+        self._pump()
 
     def _on_progress(self, value: int, maximum: int) -> None:
         if not self._stack:
@@ -114,7 +122,7 @@ class LongOperationToolbar(QToolBar):
         if self._progress_timer.elapsed() < _PROGRESS_THROTTLE_MS:
             return
         self._progress_timer.restart()
-        QApplication.processEvents()
+        self._pump()
 
     def _on_done(self) -> None:
         if not self._stack:

--- a/tilia/ui/long_operation.py
+++ b/tilia/ui/long_operation.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QEvent, QObject, Qt
+from PySide6.QtWidgets import QApplication, QDialog, QLabel, QProgressBar, QToolBar
+
+from tilia.requests import LongOperation, Post, listen
+
+
+class _DialogCursorFilter(QObject):
+    """Restores the application override cursor while any QDialog is visible,
+    then re-sets it when all dialogs close.  Installed on QApplication while a
+    long operation is running and removed when the operation finishes."""
+
+    def __init__(self, stack: list[str]) -> None:
+        super().__init__()
+        self._stack = stack
+        self._open_count = 0
+
+    def reset(self) -> None:
+        self._open_count = 0
+
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
+        if isinstance(obj, QDialog):
+            if event.type() == QEvent.Type.Show:
+                if self._open_count == 0 and QApplication.overrideCursor():
+                    QApplication.restoreOverrideCursor()
+                self._open_count += 1
+            elif event.type() == QEvent.Type.Hide:
+                self._open_count = max(0, self._open_count - 1)
+                if self._open_count == 0 and self._stack:
+                    QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        return False
+
+
+_BLOCKED_MOUSE_EVENTS = {
+    QEvent.Type.MouseButtonPress,
+    QEvent.Type.MouseButtonRelease,
+    QEvent.Type.MouseButtonDblClick,
+}
+
+
+class _InputBlockFilter(QObject):
+    """Swallows mouse button events while the application override cursor is set."""
+
+    def eventFilter(self, _: QObject, event: QEvent) -> bool:
+        return (
+            event.type() in _BLOCKED_MOUSE_EVENTS
+            and QApplication.overrideCursor() is not None
+        )
+
+
+class LongOperationToolbar(QToolBar):
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setMovable(False)
+        self.setFloatable(False)
+        self.setMaximumHeight(30)
+        self.setContextMenuPolicy(Qt.ContextMenuPolicy.PreventContextMenu)
+
+        self._bar = QProgressBar()
+        self._bar.setTextVisible(False)
+        self._bar.setFixedWidth(200)
+        self._bar_action = self.addWidget(self._bar)
+
+        self._label = QLabel()
+        self._label.setContentsMargins(4, 0, 4, 0)
+        self._label_action = self.addWidget(self._label)
+
+        self.hide()
+
+        self._stack: list[str] = []
+        self._dialog_cursor_filter = _DialogCursorFilter(self._stack)
+        self._input_block_filter = _InputBlockFilter()
+        self._app: QApplication = QApplication.instance()  # type: ignore[assignment]
+
+        listen(self, Post.LONG_OPERATION, self._on_long_operation)
+
+    def _on_long_operation(self, phase: LongOperation, *args) -> None:
+        match phase:
+            case LongOperation.STARTED:
+                self._on_started(*args)
+            case LongOperation.PROGRESS:
+                self._on_progress(*args)
+            case LongOperation.DONE:
+                self._on_done()
+
+    def _show_current(self) -> None:
+        self._label.setText(self._stack[-1])
+        self._bar.setMaximum(0)
+        self._bar.setValue(0)
+        self.show()
+
+    def _on_started(self, label: str) -> None:
+        self._stack.append(label)
+        self._show_current()
+        if len(self._stack) == 1:
+            QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+            self._app.installEventFilter(self._dialog_cursor_filter)
+            self._app.installEventFilter(self._input_block_filter)
+        QApplication.processEvents()
+
+    def _on_progress(self, value: int, maximum: int) -> None:
+        if not self._stack:
+            return
+        if self._bar.maximum() != maximum:
+            self._bar.setMaximum(maximum)
+        self._bar.setValue(value)
+        QApplication.processEvents()
+
+    def _on_done(self) -> None:
+        if not self._stack:
+            return
+        self._stack.pop()
+        if self._stack:
+            self._show_current()
+        else:
+            self.hide()
+            self._label.setText("")
+            self._bar.setMaximum(0)
+            self._bar.setValue(0)
+            self._app.removeEventFilter(self._dialog_cursor_filter)
+            self._app.removeEventFilter(self._input_block_filter)
+            self._dialog_cursor_filter.reset()
+            QApplication.restoreOverrideCursor()

--- a/tilia/ui/qtui.py
+++ b/tilia/ui/qtui.py
@@ -48,6 +48,7 @@ from .dialog_manager import DialogManager
 from .dialogs.basic import display_error
 from .dialogs.crash import CrashDialog
 from .dialogs.resize_rect import ResizeRect
+from .long_operation import LongOperationToolbar
 from .menubar import TiliaMenuBar
 from .menus import (
     TimelinesMenu,
@@ -70,6 +71,7 @@ class TiliaMainWindow(QMainWindow):
         super().__init__()
         self.setWindowTitle(tilia.constants.APP_NAME)
         self.setWindowIcon(QIcon.fromTheme("tilia"))
+        self.setStyleSheet("QMainWindow::separator { height: 0px; width: 0px; }")
         self.setAcceptDrops(True)
         self._drop_filter = FileDropEventFilter()
 
@@ -426,6 +428,11 @@ class QtUI:
 
         self.main_window.addToolBar(self.player_toolbar)
         self.main_window.addToolBar(self.options_toolbar)
+
+        self._long_op_toolbar = LongOperationToolbar()
+        self.main_window.addToolBar(
+            Qt.ToolBarArea.BottomToolBarArea, self._long_op_toolbar
+        )
 
         self._zoom_toolbar = ZoomToolbar()
         self.main_window.addToolBar(

--- a/tilia/ui/timelines/cursors.py
+++ b/tilia/ui/timelines/cursors.py
@@ -1,20 +1,6 @@
-from PySide6.QtGui import QGuiApplication
-
-
 # noinspection PyUnresolvedReferences
 class CursorMixIn:
     def __init__(self, cursor_shape, *args, **kwargs):
         super().__init__(*args, *kwargs)
-        self.cursor_shape = cursor_shape
+        self.setCursor(cursor_shape)
         self.setAcceptHoverEvents(True)
-
-    def hoverEnterEvent(self, event) -> None:
-        QGuiApplication.setOverrideCursor(self.cursor_shape)
-        super().hoverEnterEvent(event)
-
-    def hoverLeaveEvent(self, event) -> None:
-        QGuiApplication.restoreOverrideCursor()
-        super().hoverLeaveEvent(event)
-
-    def cleanup(self):
-        QGuiApplication.restoreOverrideCursor()

--- a/tilia/ui/zoom_toolbar.py
+++ b/tilia/ui/zoom_toolbar.py
@@ -84,8 +84,9 @@ class ZoomToolbar(QToolBar):
 
     def _apply_slider_stylesheet(self) -> None:
         self._slider.setStyleSheet(
-            "QSlider::groove:horizontal{height:4px;border-radius:2px;"
-            "background:palette(window-text);}"
+            "QSlider{min-height:20px;}"
+            "QSlider::groove:horizontal{height:4px;margin:8px 0;"
+            "border-radius:2px;background:palette(window-text);}"
             "QSlider::handle:horizontal{width:12px;height:12px;margin:-4px 0;"
             "border-radius:6px;background:palette(button);"
             "border:1px solid palette(button-text);}"


### PR DESCRIPTION
**Non-blocking progress feedback for long-running operations**

- New `LongOperationToolbar` (bottom-left) shows a progress bar and label during slow operations.  Stack-based nesting keeps the toolbar visible across multiple concurrent operations and restores the outer label when an inner one finishes.
- `WaitCursor` set for the full duration; `_DialogCursorFilter` lifts it while any `QDialog` is visible and restores it on close. `_InputBlockFilter` swallows mouse clicks while the cursor is active.
- `@long_operation(label)` decorator posts `STARTED`/`DONE` around a function.  The bar is indeterminate by default; posting `PROGRESS(value, maximum)` inside promotes it to determinate. `DONE` is always posted even if the function raises.
- Applied to `App._do_open`, `App._do_load_media`, and `BeatTimeline.fill_with_beats` (with per-beat `PROGRESS` posts).
- Fixes pre-existing bug: `CursorMixIn` was calling `restoreOverrideCursor()` unconditionally on hover-leave, popping the `WaitCursor` off the application stack.  Replaced with `QGraphicsItem.setCursor()`, which does not interact with the override cursor stack.

closes #545

ps. is there anything else that would benefit from this?