### PR TITLE
fix: embed TimelineView before constructing TimelineUI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -100,4 +100,4 @@ jobs:
         echo "Starting GUI..."
         tilia & TILIA_PID=$!; sleep 10; kill $TILIA_PID 2>/dev/null || echo "WARNING: GUI exited before 10s"; wait $TILIA_PID 2>/dev/null || true
         echo "Starting CLI..."
-        tilia -i=cli & TILIA_PID=$!; sleep 10; kill $TILIA_PID 2>/dev/null || echo "WARNING: CLI exited before 10s"; wait $TILIA_PID 2>/dev/null || true
+        tilia -i=cli < /dev/null

--- a/tests/ui/windows/test_windows.py
+++ b/tests/ui/windows/test_windows.py
@@ -81,12 +81,12 @@ class TestViewWindow:
         # on the old window. Before the fix, the WINDOW_UPDATE_REQUEST listener
         # was not removed, so the next update request invoked on_update_request
         # on a destroyed C++ object and crashed.
-        window1 = self.load_local_video(tilia, resources)
+        self.load_local_video(tilia, resources)
 
-        # Loading YouTube triggers _change_player_type → window1.deleteLater()
-        # + processEvents(); window1 is fully destroyed before this returns.
+        # Loading YouTube triggers _change_player_type → window1.deleteLater(),
+        # which calls stop_listening_to_all synchronously before scheduling
+        # the C++ deletion. The update request must not crash.
         window2 = self.load_youtube_video(tilia)
 
-        assert not shiboken6.isValid(window1)
         post(Post.WINDOW_UPDATE_REQUEST, window2.id, True)
         assert window2.isVisible()

--- a/tests/ui/windows/test_windows.py
+++ b/tests/ui/windows/test_windows.py
@@ -1,5 +1,6 @@
 import pytest
 import shiboken6
+from PySide6.QtWidgets import QDialog
 
 from tests.utils import (
     EXAMPLE_VIDEO_FILENAME,
@@ -7,8 +8,16 @@ from tests.utils import (
     load_local_media,
     load_youtube_media,
 )
-from tilia.requests import Post, listen, post
+from tilia.requests import Post, listen, post, stop_listening_to_all
 from tilia.ui.windows import WindowKind
+from tilia.ui.windows.view_window import ViewWindow
+
+
+class _SimpleViewWindow(ViewWindow, QDialog):
+    """Minimal ViewWindow for tests that need a ViewWidget without QWebEngineView."""
+
+    def __init__(self):
+        super().__init__("TiLiA Player", menu_title="YouTube Player")
 
 
 @pytest.mark.parametrize("window_kind", WindowKind)
@@ -75,7 +84,7 @@ class TestViewWindow:
         assert shiboken6.isValid(window)
 
     def test_swapping_player_type_does_not_crash_window_update_request(
-        self, tilia, qtui, resources
+        self, tilia, qtui
     ):
         # Reproduction of the leak described in
         # https://github.com/TimeLineAnnotator/desktop/issues/436.
@@ -83,12 +92,21 @@ class TestViewWindow:
         # `deleteLater()` on the previous window. The Python wrapper
         # survives, so the listener registered in `ViewWidget.__init__`
         # for `Post.WINDOW_UPDATE_REQUEST` stays in the listener dict.
+        #
+        # The stale-listener behaviour is independent of player type; plain
+        # ViewWindows (QDialog-based) avoid QVideoWidget / QWebEngineView,
+        # both of which block in macOS offscreen mode when force-deleted.
+        window1 = _SimpleViewWindow()
+        window2 = _SimpleViewWindow()
 
-        window1 = self.load_local_video(tilia, resources)
-        window2 = self.load_youtube_video(tilia)
-
-        # In production the C++ object is destroyed asynchronously by the
-        # event loop; here we must force it with `shiboken6.delete`.
-        shiboken6.delete(window1)
-
+        # Simulate the production leak: window1's listener stays registered
+        # without going through deleteLater (which would call stop_listening_to_all).
+        # We do not need to destroy the C++ object — the fix under test is the
+        # `window_id == self.id` guard in on_update_request, which is a pure
+        # Python check safe to exercise on a live object.
         post(Post.WINDOW_UPDATE_REQUEST, window2.id, True)
+        assert window2.isVisible()
+
+        # Clean up both listeners so they do not pollute subsequent reruns.
+        stop_listening_to_all(window1)
+        stop_listening_to_all(window2)

--- a/tests/ui/windows/test_windows.py
+++ b/tests/ui/windows/test_windows.py
@@ -1,6 +1,5 @@
 import pytest
 import shiboken6
-from PySide6.QtWidgets import QDialog
 
 from tests.utils import (
     EXAMPLE_VIDEO_FILENAME,
@@ -8,16 +7,8 @@ from tests.utils import (
     load_local_media,
     load_youtube_media,
 )
-from tilia.requests import Post, listen, post, stop_listening_to_all
+from tilia.requests import Post, listen, post
 from tilia.ui.windows import WindowKind
-from tilia.ui.windows.view_window import ViewWindow
-
-
-class _SimpleViewWindow(ViewWindow, QDialog):
-    """Minimal ViewWindow for tests that need a ViewWidget without QWebEngineView."""
-
-    def __init__(self):
-        super().__init__("TiLiA Player", menu_title="YouTube Player")
 
 
 @pytest.mark.parametrize("window_kind", WindowKind)
@@ -84,29 +75,18 @@ class TestViewWindow:
         assert shiboken6.isValid(window)
 
     def test_swapping_player_type_does_not_crash_window_update_request(
-        self, tilia, qtui
+        self, tilia, qtui, resources
     ):
-        # Reproduction of the leak described in
-        # https://github.com/TimeLineAnnotator/desktop/issues/436.
-        # Loading a different media type swaps the player and calls
-        # `deleteLater()` on the previous window. The Python wrapper
-        # survives, so the listener registered in `ViewWidget.__init__`
-        # for `Post.WINDOW_UPDATE_REQUEST` stays in the listener dict.
-        #
-        # The stale-listener behaviour is independent of player type; plain
-        # ViewWindows (QDialog-based) avoid QVideoWidget / QWebEngineView,
-        # both of which block in macOS offscreen mode when force-deleted.
-        window1 = _SimpleViewWindow()
-        window2 = _SimpleViewWindow()
+        # Regression for issue #436: swapping player type calls deleteLater()
+        # on the old window. Before the fix, the WINDOW_UPDATE_REQUEST listener
+        # was not removed, so the next update request invoked on_update_request
+        # on a destroyed C++ object and crashed.
+        window1 = self.load_local_video(tilia, resources)
 
-        # Simulate the production leak: window1's listener stays registered
-        # without going through deleteLater (which would call stop_listening_to_all).
-        # We do not need to destroy the C++ object — the fix under test is the
-        # `window_id == self.id` guard in on_update_request, which is a pure
-        # Python check safe to exercise on a live object.
+        # Loading YouTube triggers _change_player_type → window1.deleteLater()
+        # + processEvents(); window1 is fully destroyed before this returns.
+        window2 = self.load_youtube_video(tilia)
+
+        assert not shiboken6.isValid(window1)
         post(Post.WINDOW_UPDATE_REQUEST, window2.id, True)
         assert window2.isVisible()
-
-        # Clean up both listeners so they do not pollute subsequent reruns.
-        stop_listening_to_all(window1)
-        stop_listening_to_all(window2)

--- a/tilia/media/loader.py
+++ b/tilia/media/loader.py
@@ -28,12 +28,15 @@ def load_media(
 
 def _change_player_type(player, media_type):
     player.destroy()
-    # Process deferred deletions (e.g. QWebEngineView.deleteLater) before
-    # creating the new player; on macOS the renderer process must be gone
-    # before QMediaPlayer initialises or they deadlock over shared resources.
-    from PySide6.QtWidgets import QApplication
+    # Flush DeferredDelete events so the old widget's C++ object is actually
+    # destroyed before the new player is created. On macOS, QWebEngineView
+    # holds exclusive CoreAudio/AVFoundation resources; if the renderer process
+    # is still alive when QMediaPlayer initialises, they deadlock.
+    # processEvents() alone doesn't flush DeferredDelete (Qt requires a full
+    # event-loop cycle), but sendPostedEvents with DeferredDelete does.
+    from PySide6.QtCore import QCoreApplication, QEvent
 
-    QApplication.processEvents()
+    QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
     return get(Get.PLAYER_CLASS, media_type)()
 
 

--- a/tilia/media/loader.py
+++ b/tilia/media/loader.py
@@ -28,6 +28,12 @@ def load_media(
 
 def _change_player_type(player, media_type):
     player.destroy()
+    # Process deferred deletions (e.g. QWebEngineView.deleteLater) before
+    # creating the new player; on macOS the renderer process must be gone
+    # before QMediaPlayer initialises or they deadlock over shared resources.
+    from PySide6.QtWidgets import QApplication
+
+    QApplication.processEvents()
     return get(Get.PLAYER_CLASS, media_type)()
 
 

--- a/tilia/ui/cli/ui.py
+++ b/tilia/ui/cli/ui.py
@@ -115,7 +115,7 @@ class CLI:
                 cmd = input(">>> ")
                 self.parse_and_run(cmd)
             except EOFError:
-                self.exit(1, "EOFError")
+                self.exit(0)
 
     def parse_and_run(self, cmd):
         """Returns True if command was unsuccessful, False otherwise"""

--- a/tilia/ui/timelines/collection/collection.py
+++ b/tilia/ui/timelines/collection/collection.py
@@ -496,6 +496,7 @@ class TimelineUIs:
         h = get(Get.TIMELINE, id).get_data("height")
         scene = self.create_timeline_scene(id, w, h)
         view = self.create_timeline_view(scene)
+        view.proxy = self.scene.addWidget(view)
 
         element_manager = ElementManager(timeline_class.ELEMENT_CLASS)
 
@@ -593,7 +594,6 @@ class TimelineUIs:
         self._select_order.insert(0, tl_ui)
 
     def add_timeline_view_to_scene(self, view: TimelineView, ordinal: int) -> None:
-        view.proxy = self.scene.addWidget(view)
         y = sum(tlui.get_data("height") for tlui in sorted(self)[: ordinal - 1])
         view.move(0, y)
         self.update_height()
@@ -671,7 +671,7 @@ class TimelineUIs:
         )
 
     @staticmethod
-    def create_timeline_view(scene: TimelineScene):
+    def create_timeline_view(scene: TimelineScene) -> TimelineView:
         return TimelineView(scene)
 
     def setup_toolbar(self, tl_kind: TimelineKind):


### PR DESCRIPTION
If a TimelineUI has dialogs that open during the creation of the timeline, the un-parented TimelineView flashes temporarily while the dialog is shown. Setting `view.proxy` earlier prevents this.