### PR TITLE
feat: version-aware .tla loading with migrations

### DIFF
--- a/tests/file/test_migration.py
+++ b/tests/file/test_migration.py
@@ -22,6 +22,16 @@ def make_timeline(kind, **extra):
     }
 
 
+def make_pre_0_1_1_timeline(kind, display_position, **extra):
+    """A timeline dict as written before the 0.1.1 ordinal migration.
+
+    Pre-0.1.1 files have ``display_position``, not ``ordinal``.
+    """
+    timeline = make_timeline(kind, display_position=display_position, **extra)
+    del timeline["ordinal"]
+    return timeline
+
+
 def make_tla(version, timelines=None):
     return {
         "file_path": "",
@@ -70,9 +80,8 @@ class TestMigrate:
     def test_display_position_to_ordinal(self):
         data = make_tla(
             "0.1.0",
-            {"0": make_timeline("MARKER_TIMELINE", display_position=3)},
+            {"0": make_pre_0_1_1_timeline("MARKER_TIMELINE", display_position=3)},
         )
-        del data["timelines"]["0"]["ordinal"]
 
         migrated, applied = migrate(data, app_version="0.6.2")
 
@@ -102,9 +111,8 @@ class TestMigrate:
     def test_chaining_runs_all_applicable_migrations(self):
         data = make_tla(
             "0.1.0",
-            {"0": make_timeline("HIERARCHY_TIMELINE", display_position=0)},
+            {"0": make_pre_0_1_1_timeline("HIERARCHY_TIMELINE", display_position=0)},
         )
-        del data["timelines"]["0"]["ordinal"]
 
         migrated, applied = migrate(data, app_version="0.7.0")
 

--- a/tests/file/test_migration.py
+++ b/tests/file/test_migration.py
@@ -1,0 +1,159 @@
+import json
+
+from tests.mock import Serve
+from tilia.file.file_manager import open_tla
+from tilia.file.migration import (
+    _parse_version,
+    is_from_newer_version,
+    migrate,
+)
+from tilia.requests import Get
+
+
+def make_timeline(kind, **extra):
+    return {
+        "height": 220,
+        "is_visible": True,
+        "name": "tl",
+        "ordinal": 1,
+        "components": {},
+        "kind": kind,
+        **extra,
+    }
+
+
+def make_tla(version, timelines=None):
+    return {
+        "file_path": "",
+        "media_path": "",
+        "media_metadata": {},
+        "timelines": timelines or {},
+        "app_name": "TiLiA",
+        "version": version,
+    }
+
+
+class TestParseVersion:
+    def test_simple(self):
+        assert _parse_version("0.6.2") == (0, 6, 2)
+
+    def test_ignores_suffix(self):
+        assert _parse_version("0.7.0rc1") == (0, 7, 0)
+
+    def test_empty_sorts_first(self):
+        assert _parse_version("") == (0,)
+        assert _parse_version("") < _parse_version("0.0.1")
+
+    def test_ordering(self):
+        assert _parse_version("0.6.2") < _parse_version("0.7.0")
+        assert _parse_version("0.7.0") < _parse_version("0.7.1")
+        assert _parse_version("0.7.0") < _parse_version("1.0.0")
+
+
+class TestIsFromNewerVersion:
+    def test_newer(self):
+        assert is_from_newer_version(make_tla("0.8.0"), app_version="0.7.0")
+
+    def test_equal(self):
+        assert not is_from_newer_version(make_tla("0.7.0"), app_version="0.7.0")
+
+    def test_older(self):
+        assert not is_from_newer_version(make_tla("0.6.2"), app_version="0.7.0")
+
+    def test_missing_version(self):
+        data = make_tla("0.7.0")
+        del data["version"]
+        assert not is_from_newer_version(data, app_version="0.7.0")
+
+
+class TestMigrate:
+    def test_display_position_to_ordinal(self):
+        data = make_tla(
+            "0.1.0",
+            {"0": make_timeline("MARKER_TIMELINE", display_position=3)},
+        )
+        del data["timelines"]["0"]["ordinal"]
+
+        migrated, applied = migrate(data, app_version="0.6.2")
+
+        tl = migrated["timelines"]["0"]
+        assert tl["ordinal"] == 4  # display_position + 1
+        assert "display_position" not in tl
+        assert "0.1.1" in applied
+
+    def test_kind_migration_dormant_below_target_app_version(self):
+        # On a pre-0.7 app, the kind must stay in the old format the app reads.
+        data = make_tla("0.6.0", {"0": make_timeline("MARKER_TIMELINE")})
+
+        migrated, applied = migrate(data, app_version="0.6.2")
+
+        assert migrated["timelines"]["0"]["kind"] == "MARKER_TIMELINE"
+        assert applied == []
+
+    def test_kind_migration_active_at_target_app_version(self):
+        data = make_tla("0.6.2", {"0": make_timeline("MARKER_TIMELINE")})
+
+        migrated, applied = migrate(data, app_version="0.7.0")
+
+        assert migrated["timelines"]["0"]["kind"] == "Marker"
+        assert applied == ["0.7.0"]
+        assert migrated["version"] == "0.7.0"
+
+    def test_chaining_runs_all_applicable_migrations(self):
+        data = make_tla(
+            "0.1.0",
+            {"0": make_timeline("HIERARCHY_TIMELINE", display_position=0)},
+        )
+        del data["timelines"]["0"]["ordinal"]
+
+        migrated, applied = migrate(data, app_version="0.7.0")
+
+        tl = migrated["timelines"]["0"]
+        assert tl["ordinal"] == 1
+        assert "display_position" not in tl
+        assert tl["kind"] == "Hierarchy"
+        assert applied == ["0.1.1", "0.7.0"]
+        assert migrated["version"] == "0.7.0"
+
+    def test_current_file_is_noop(self):
+        data = make_tla("0.6.2", {"0": make_timeline("MARKER_TIMELINE")})
+
+        migrated, applied = migrate(data, app_version="0.6.2")
+
+        assert applied == []
+        assert migrated["timelines"]["0"]["kind"] == "MARKER_TIMELINE"
+        assert migrated["version"] == "0.6.2"
+
+    def test_defensive_with_missing_fields(self):
+        # Empty timelines and a kind already in new format must not raise.
+        data = make_tla("0.1.0")
+        migrate(data, app_version="0.7.0")
+
+        data = make_tla("0.1.0", {"0": {"kind": "Marker"}})
+        migrated, _ = migrate(data, app_version="0.7.0")
+        assert migrated["timelines"]["0"]["kind"] == "Marker"
+
+
+class TestOpenTlaNewerVersionWarning:
+    def _write(self, tmp_path, data):
+        path = tmp_path / "newer.tla"
+        path.write_text(json.dumps(data), encoding="utf-8")
+        return path
+
+    def test_decline_aborts_open(self, tmp_path):
+        path = self._write(tmp_path, make_tla("99.0.0"))
+
+        with Serve(Get.FROM_USER_YES_OR_NO, False):
+            success, file, old_path = open_tla(path)
+
+        assert success is False
+        assert file is None
+
+    def test_accept_proceeds_with_open(self, tmp_path):
+        path = self._write(tmp_path, make_tla("99.0.0"))
+
+        with Serve(Get.FROM_USER_YES_OR_NO, True):
+            success, file, _ = open_tla(path)
+
+        assert success is True
+        assert file is not None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -23,6 +23,7 @@ from tests.utils import (
     save_and_reopen,
     save_tilia_to_tmp_path,
 )
+from tilia.file.migration import find_unknown_timeline_kinds
 from tilia.media.player import QtAudioPlayer, YouTubePlayer
 from tilia.requests import Get, Post, get, post
 from tilia.settings import settings
@@ -381,6 +382,34 @@ def assert_open_failed(tilia, tilia_errors, opened_file_path, prev_file):
     assert tilia.file_manager.file == prev_file
 
 
+UNKNOWN_TIMELINE_KIND = "SOME_FUTURE_TIMELINE_KIND"
+UNKNOWN_TIMELINE_ID = "0"
+KNOWN_TIMELINE_ID = "1"
+
+
+def get_file_data_with_unknown_timeline_kind():
+    file_data = tests.utils.get_blank_file_data()
+    file_data["version"] = "99.0.0"
+    file_data["timelines"] = {
+        UNKNOWN_TIMELINE_ID: {
+            "is_visible": True,
+            "ordinal": 1,
+            "height": 40,
+            "kind": UNKNOWN_TIMELINE_KIND,
+            "components": {},
+        },
+        KNOWN_TIMELINE_ID: {
+            "is_visible": True,
+            "ordinal": 2,
+            "height": 40,
+            "kind": "MARKER_TIMELINE",
+            "components": {},
+            "components_hash": "d41d8cd98f00b204e9800998ecf8427e",
+        },
+    }
+    return file_data
+
+
 class TestOpen:
     def test_open_with_timeline(self, tilia, tls, tmp_path):
         tl_data = tests.utils.get_dummy_timeline_data()
@@ -451,6 +480,154 @@ class TestOpen:
 
         assert_open_failed(tilia, tilia_errors, tmp_file, prev_file)
 
+    def test_open_newer_file_with_unknown_timeline_kind_user_cancels(
+        self, tilia, tmp_path, tilia_errors
+    ):
+        prev_file = tilia.file_manager.file
+        tmp_file = tmp_path / "test.tla"
+        tmp_file.write_text(json.dumps(get_file_data_with_unknown_timeline_kind()))
+
+        with (
+            Serve(Get.FROM_USER_YES_OR_NO, True),
+            Serve(Get.FROM_USER_UNKNOWN_TIMELINE_KIND_ACTION, (False, False)),
+        ):
+            commands.execute("file.open", tmp_file)
+
+        tilia_errors.assert_no_error()
+        assert settings.get_recent_files()[0] != tmp_file
+        assert tilia.file_manager.file == prev_file
+
+    def test_open_newer_file_with_unknown_timeline_kind_user_deletes(
+        self, tilia, tmp_path, tilia_errors
+    ):
+        tmp_file = tmp_path / "test.tla"
+        tmp_file.write_text(json.dumps(get_file_data_with_unknown_timeline_kind()))
+
+        with (
+            Serve(Get.FROM_USER_YES_OR_NO, True),
+            Serve(Get.FROM_USER_UNKNOWN_TIMELINE_KIND_ACTION, (True, True)),
+        ):
+            commands.execute("file.open", tmp_file)
+
+        tilia_errors.assert_no_error()
+        assert Path(settings.get_recent_files()[0]) == tmp_file
+        assert UNKNOWN_TIMELINE_ID not in {tl.id for tl in tilia.timelines}
+        assert tilia.file_manager.file.unknown_timelines == {}
+        assert tilia.file_manager.file.timelines[UNKNOWN_TIMELINE_ID]["kind"] == (
+            UNKNOWN_TIMELINE_KIND
+        )
+        assert tilia.is_file_modified()
+
+        known = tilia.file_manager.file.timelines[KNOWN_TIMELINE_ID]
+        assert known["kind"] == "MARKER_TIMELINE"
+        assert known["ordinal"] == 1
+
+    def test_open_newer_file_with_unknown_timeline_kind_user_ignores(
+        self, tilia, tmp_path, tilia_errors
+    ):
+        tmp_file = tmp_path / "test.tla"
+        tmp_file.write_text(json.dumps(get_file_data_with_unknown_timeline_kind()))
+
+        with (
+            Serve(Get.FROM_USER_YES_OR_NO, True),
+            Serve(Get.FROM_USER_UNKNOWN_TIMELINE_KIND_ACTION, (True, False)),
+        ):
+            commands.execute("file.open", tmp_file)
+
+        tilia_errors.assert_no_error()
+        assert UNKNOWN_TIMELINE_ID not in {tl.id for tl in tilia.timelines}
+        assert tilia.file_manager.file.timelines[UNKNOWN_TIMELINE_ID]["kind"] == (
+            UNKNOWN_TIMELINE_KIND
+        )
+        assert (
+            tilia.file_manager.file.unknown_timelines[UNKNOWN_TIMELINE_ID]["kind"]
+            == UNKNOWN_TIMELINE_KIND
+        )
+
+        live_hashes = {
+            tl["components_hash"] for tl in tilia.get_app_state()["timelines"].values()
+        }
+        stored_hashes = {
+            tl["components_hash"] for tl in tilia.file_manager.file.timelines.values()
+        }
+        assert live_hashes == stored_hashes
+
+        known = tilia.file_manager.file.timelines[KNOWN_TIMELINE_ID]
+        assert known["kind"] == "MARKER_TIMELINE"
+        assert known["ordinal"] == 1
+        ordinals = [tl["ordinal"] for tl in tilia.file_manager.file.timelines.values()]
+        assert len(ordinals) == len(set(ordinals))
+        assert UNKNOWN_TIMELINE_ID not in {tl.id for tl in tilia.timelines}
+
+    def test_reserved_id_survives_a_lower_explicit_id_processed_after(
+        self, tilia, tmp_path, tilia_errors
+    ):
+        file_data = tests.utils.get_blank_file_data()
+        file_data["version"] = "99.0.0"
+        file_data["timelines"] = {
+            "1": {
+                "is_visible": True,
+                "ordinal": 1,
+                "height": 40,
+                "kind": UNKNOWN_TIMELINE_KIND,
+                "components": {},
+            },
+            "0": {
+                "is_visible": True,
+                "ordinal": 2,
+                "height": 40,
+                "kind": "MARKER_TIMELINE",
+                "components": {},
+            },
+        }
+        tmp_file = tmp_path / "test.tla"
+        tmp_file.write_text(json.dumps(file_data))
+
+        with (
+            Serve(Get.FROM_USER_YES_OR_NO, True),
+            Serve(Get.FROM_USER_UNKNOWN_TIMELINE_KIND_ACTION, (True, False)),
+        ):
+            commands.execute("file.open", tmp_file)
+
+        tilia_errors.assert_no_error()
+        live_ids = {tl.id for tl in tilia.timelines}
+        assert "0" in live_ids  # the known timeline
+        assert "1" not in live_ids  # reserved by the ignored timeline
+
+    def test_ignored_unknown_timeline_survives_a_save(
+        self, tilia, qtui, tmp_path, tilia_errors
+    ):
+        open_path = tmp_path / "test.tla"
+        open_path.write_text(json.dumps(get_file_data_with_unknown_timeline_kind()))
+
+        with (
+            Serve(Get.FROM_USER_YES_OR_NO, True),
+            Serve(Get.FROM_USER_UNKNOWN_TIMELINE_KIND_ACTION, (True, False)),
+        ):
+            commands.execute("file.open", open_path)
+
+        save_path = tmp_path / "resaved.tla"
+        with patch_file_dialog(True, [str(save_path)]):
+            commands.execute("file.save_as")
+
+        saved_data = json.loads(save_path.read_text())
+        assert saved_data["timelines"][UNKNOWN_TIMELINE_ID]["kind"] == (
+            UNKNOWN_TIMELINE_KIND
+        )
+        assert "unknown_timelines" not in saved_data
+
+        assert saved_data["timelines"][KNOWN_TIMELINE_ID]["ordinal"] == 1
+        assert (
+            saved_data["timelines"][UNKNOWN_TIMELINE_ID]["ordinal"] == 3
+        )  # slider timeline is 2
+        ordinals = [tl["ordinal"] for tl in saved_data["timelines"].values()]
+        assert len(ordinals) == len(set(ordinals))
+
+    def test_known_kind_is_loaded_normally_not_flagged_unknown(self):
+        file_data = get_file_data_with_unknown_timeline_kind()
+        file_data["timelines"][UNKNOWN_TIMELINE_ID]["kind"] = "MARKER_TIMELINE"
+        assert find_unknown_timeline_kinds(file_data) == {}
+
     def test_file_not_modified_after_open(self, tilia, tmp_path):
         file_data = tests.utils.get_blank_file_data()
         tl_data = tests.utils.get_dummy_timeline_data()
@@ -461,6 +638,16 @@ class TestOpen:
         tilia.on_clear()
         commands.execute("file.open", file_path)
         assert not tilia.file_manager.is_file_modified(tilia.file_manager.file.__dict__)
+
+    def test_default_slider_timeline_reflected_in_baseline(self, tilia, tmp_path):
+        file_data = tests.utils.get_blank_file_data()
+        file_data["timelines"] = tests.utils.get_dummy_timeline_data()  # no slider
+        tmp_file = tmp_path / "test.tla"
+        tmp_file.write_text(json.dumps(file_data))
+
+        commands.execute("file.open", tmp_file)
+
+        assert not tilia.is_file_modified()
 
     def test_open_file_with_custom_metadata_fields(self, tilia, tmp_path):
         file_data = """{

--- a/tests/timelines/test_timeline_collection.py
+++ b/tests/timelines/test_timeline_collection.py
@@ -109,40 +109,6 @@ class TestTimelines:
         tls.delete_timeline(tls[0])
         assert tls.serve_ordinal_for_new_timeline() == 1
 
-    def test_deserialize_timelines_with_display_position(self, tls):
-        data = {
-            0: {
-                "height": 220,
-                "is_visible": True,
-                "name": "test1",
-                "display_position": 0,
-                "components": {},
-                "kind": TimelineKind.HIERARCHY_TIMELINE,
-            },
-            1: {
-                "height": 220,
-                "is_visible": True,
-                "name": "test2",
-                "display_position": 1,
-                "components": {},
-                "kind": TimelineKind.MARKER_TIMELINE,
-            },
-        }
-
-        tls.deserialize_timelines(data)
-
-        # assert timelines where created in right order
-        assert tls[0].name == "test1"
-        assert tls[1].name == "test2"
-
-        # assert ordinal property has been set
-        assert tls[0].ordinal == 1
-        assert tls[1].ordinal == 2
-
-        # assert display_position attribute was not created
-        assert not hasattr(tls[0], "display_position")
-        assert not hasattr(tls[1], "display_position")
-
     def test_serialize_timelines_serializes_ordinals(self, tls):
         tl1 = tls.create_timeline(TimelineKind.SLIDER_TIMELINE)
         tl2 = tls.create_timeline(TimelineKind.HIERARCHY_TIMELINE)

--- a/tilia/app.py
+++ b/tilia/app.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import itertools
 import json
 import os
 import re
@@ -163,11 +162,24 @@ class App:
 
         self.old_file_path = old_path
         self.cur_file_path = Path(file.file_path)
+        if file.unknown_timelines or file.deleted_timelines:
+            self._reserve_ids({**file.unknown_timelines, **file.deleted_timelines})
 
         success = self.on_file_load(file)
         if not success:
             self.on_restore_state(prev_state)
             return
+
+        file.timelines, file.timelines_hash = self.get_timelines_state()
+
+        if file.unknown_timelines or file.deleted_timelines:
+            file.timelines = {
+                **self._renumber_ordinal_for_append(
+                    file.unknown_timelines, file.timelines
+                ),
+                **file.deleted_timelines,
+                **file.timelines,
+            }
 
         self.file_manager.file = file
         post(Post.APP_FILE_LOADED, file)
@@ -291,10 +303,10 @@ class App:
 
         def handle_invalid_id(id):
             tilia.errors.display(tilia.errors.INVALID_ID, id)
-            return str(next(self._id_counter))
+            return self._next_available_id()
 
         if id is None:
-            return str(next(self._id_counter))
+            return self._next_available_id()
 
         if type(id) not in [int, str]:
             return handle_invalid_id(id)
@@ -314,15 +326,35 @@ class App:
         existing_ids = timeline_ids.union(component_ids)
 
         if int_id in existing_ids:
-            return str(next(self._id_counter))
+            return self._next_available_id()
 
-        if not existing_ids or int_id > max(existing_ids):
-            self._id_counter = itertools.count(int_id + 1)
+        self._next_id = max(self._next_id, int_id + 1)
 
         return str(int_id)
 
+    def _next_available_id(self) -> str:
+        id = self._next_id
+        self._next_id += 1
+        return str(id)
+
     def reset_id_generator(self):
-        self._id_counter = itertools.count()
+        self._next_id = 0
+
+    def _reserve_ids(self, unknown_timelines: dict) -> None:
+        def to_int(value):
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return None
+
+        ids = [
+            n
+            for timeline_id, timeline_data in unknown_timelines.items()
+            for i in (timeline_id, *timeline_data.get("components", {}))
+            if (n := to_int(i)) is not None
+        ]
+        if ids:
+            self._next_id = max(self._next_id, max(ids) + 1)
 
     def on_media_duration_changed(self, duration: float):
         if not self.timelines.is_blank and duration != self.duration:
@@ -478,11 +510,31 @@ class App:
     def get_timelines_state(self):
         return self.timelines.serialize_timelines()
 
+    @staticmethod
+    def _renumber_ordinal_for_append(
+        unknown_timelines: dict, live_timelines: dict
+    ) -> dict:
+        if not unknown_timelines:
+            return {}
+        live_max = max(
+            (tl.get("ordinal", 0) for tl in live_timelines.values()), default=0
+        )
+        ordered_ids = sorted(
+            unknown_timelines, key=lambda id: unknown_timelines[id].get("ordinal", 0)
+        )
+        return {
+            id: {**unknown_timelines[id], "ordinal": live_max + offset}
+            for offset, id in enumerate(ordered_ids, start=1)
+        }
+
     def get_app_state(self) -> dict:
         timelines_state, timelines_hash = self.timelines.serialize_timelines()
+        unknown_timelines = self._renumber_ordinal_for_append(
+            self.file_manager.file.unknown_timelines, timelines_state
+        )
         params = {
             "media_metadata": dict(self.file_manager.file.media_metadata),
-            "timelines": timelines_state,
+            "timelines": {**unknown_timelines, **timelines_state},
             "timelines_hash": timelines_hash,
             "media_path": get(Get.MEDIA_PATH),
             "file_path": self.file_manager.get_file_path(),

--- a/tilia/file/common.py
+++ b/tilia/file/common.py
@@ -34,8 +34,15 @@ def write_tilia_file_to_disk(file: TiliaFile, path: str | Path):
         tilia.constants.YOUTUBE_URL_REGEX, file.media_path
     ):
         file.media_path = Path(file.media_path).as_posix()
+    # unknown_timelines are already folded into timelines in app.get_app_state().
+    # The remaining unknown_timelines/deleted_timelines are runtime-only bookkeeping.
+    data = {
+        k: v
+        for k, v in file.__dict__.items()
+        if k not in ("unknown_timelines", "deleted_timelines")
+    }
     with open(path, "w", encoding="utf-8") as f:
-        json.dump(file.__dict__, f, **JSON_CONFIG)
+        json.dump(data, f, **JSON_CONFIG)
 
 
 def validate_save_path(path: Path):

--- a/tilia/file/file_manager.py
+++ b/tilia/file/file_manager.py
@@ -21,7 +21,7 @@ from tilia.ui import commands
 OPEN_FILE_NEWER_VERSION_TITLE = "Open file from a newer version?"
 OPEN_FILE_NEWER_VERSION_PROMPT = (
     "This file was created with TiLiA {} but you are running {}.\n"
-    "It may not load correctly, and saving could discard data that this "
+    "Errors may occur, and saving could permanently discard data that this "
     "version doesn't understand.\n\n"
     "Open it anyway?"
 )

--- a/tilia/file/file_manager.py
+++ b/tilia/file/file_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import tilia.constants
 import tilia.errors
 from tilia.exceptions import (
     MediaMetadataFieldAlreadyExists,
@@ -11,10 +12,19 @@ from tilia.exceptions import (
 )
 from tilia.file.common import are_tilia_data_equal, write_tilia_file_to_disk
 from tilia.file.media_metadata import MediaMetadata
+from tilia.file.migration import is_from_newer_version, migrate
 from tilia.file.tilia_file import TiliaFile, validate_tla_data
 from tilia.requests import Get, Post, get, listen, post, serve
 from tilia.settings import settings
 from tilia.ui import commands
+
+OPEN_FILE_NEWER_VERSION_TITLE = "Open file from a newer version?"
+OPEN_FILE_NEWER_VERSION_PROMPT = (
+    "This file was created with TiLiA {} but you are running {}.\n"
+    "It may not load correctly, and saving could discard data that this "
+    "version doesn't understand.\n\n"
+    "Open it anyway?"
+)
 
 
 def open_tla(file_path: str | Path) -> tuple[bool, TiliaFile | None, Path | None]:
@@ -36,6 +46,19 @@ def open_tla(file_path: str | Path) -> tuple[bool, TiliaFile | None, Path | None
     if not valid:
         tilia.errors.display(tilia.errors.OPEN_FILE_INVALID_TLA, file_path, reason)
         return False, None, None
+
+    if is_from_newer_version(data):
+        proceed = get(
+            Get.FROM_USER_YES_OR_NO,
+            OPEN_FILE_NEWER_VERSION_TITLE,
+            OPEN_FILE_NEWER_VERSION_PROMPT.format(
+                data.get("version", "?"), tilia.constants.VERSION
+            ),
+        )
+        if not proceed:
+            return False, None, None
+
+    data, _ = migrate(data)
 
     old_path = Path(data["file_path"])
 

--- a/tilia/file/file_manager.py
+++ b/tilia/file/file_manager.py
@@ -12,10 +12,15 @@ from tilia.exceptions import (
 )
 from tilia.file.common import are_tilia_data_equal, write_tilia_file_to_disk
 from tilia.file.media_metadata import MediaMetadata
-from tilia.file.migration import is_from_newer_version, migrate
+from tilia.file.migration import (
+    find_unknown_timeline_kinds,
+    is_from_newer_version,
+    migrate,
+)
 from tilia.file.tilia_file import TiliaFile, validate_tla_data
 from tilia.requests import Get, Post, get, listen, post, serve
 from tilia.settings import settings
+from tilia.timelines.hash_timelines import hash_function
 from tilia.ui import commands
 
 OPEN_FILE_NEWER_VERSION_TITLE = "Open file from a newer version?"
@@ -25,6 +30,43 @@ OPEN_FILE_NEWER_VERSION_PROMPT = (
     "version doesn't understand.\n\n"
     "Open it anyway?"
 )
+
+
+def _pop_unknown_timelines(data: dict, unknown_kinds: dict) -> dict:
+    return {id: data["timelines"].pop(id) for id in unknown_kinds}
+
+
+def _ensure_components_hash(timelines: dict) -> dict:
+    """Fills in a ``"components_hash"`` for any entry missing one, mutating
+    and returning ``timelines``.
+
+    A raw timeline entry that was popped and kept as unknown never goes
+    through ``Timeline.get_state()`` (it's never turned into a live
+    component tree), so it lacks the ``"components_hash"`` key every other
+    entry in ``file.timelines`` has. ``are_tilia_data_equal`` reads that key
+    unconditionally when checking "is the file modified", so a missing one
+    would raise ``KeyError`` the moment an ignored timeline is present.
+    """
+    for timeline in timelines.values():
+        if "components_hash" not in timeline:
+            timeline["components_hash"] = hash_function(
+                json.dumps(timeline.get("components", {}), sort_keys=True)
+            )
+    return timelines
+
+
+def _compact_ordinals(timelines: dict) -> None:
+    """Renumbers ``"ordinal"`` to a dense ``1..N`` sequence in place,
+    preserving relative order.
+
+    Needed after popping unknown-kind timelines: leaving a gap (e.g. 1, 3
+    after removing ordinal 2) means the next auto-assigned ordinal
+    (``len(timelines) + 1``) can land back on an ordinal that's still in
+    use, since that count no longer matches the highest ordinal in play.
+    """
+    ordered = sorted(timelines.items(), key=lambda item: item[1].get("ordinal", 0))
+    for new_ordinal, (_, timeline) in enumerate(ordered, start=1):
+        timeline["ordinal"] = new_ordinal
 
 
 def open_tla(file_path: str | Path) -> tuple[bool, TiliaFile | None, Path | None]:
@@ -60,12 +102,38 @@ def open_tla(file_path: str | Path) -> tuple[bool, TiliaFile | None, Path | None
 
     data, _ = migrate(data)
 
+    unknown_kinds = find_unknown_timeline_kinds(data)
+    ignored_timelines = {}
+    deleted_timelines = {}
+    if unknown_kinds:
+        proceed, delete = get(
+            Get.FROM_USER_UNKNOWN_TIMELINE_KIND_ACTION, list(unknown_kinds.values())
+        )
+        if not proceed:
+            return False, None, None
+        popped = _ensure_components_hash(_pop_unknown_timelines(data, unknown_kinds))
+        _compact_ordinals(data["timelines"])
+        if delete:
+            deleted_timelines = popped
+        else:
+            ignored_timelines = popped
+
     old_path = Path(data["file_path"])
 
     data["file_path"] = (
         file_path if isinstance(file_path, str) else str(file_path.resolve())
     )
-    return True, TiliaFile(**data), old_path
+    return (
+        True,
+        (
+            TiliaFile(
+                **data,
+                unknown_timelines=ignored_timelines,
+                deleted_timelines=deleted_timelines,
+            )
+        ),
+        old_path,
+    )
 
 
 class FileManager:
@@ -256,8 +324,8 @@ class FileManager:
 
     def save(self, data: dict, path: Path | str):
         data["file_path"] = str(path.resolve()) if isinstance(path, Path) else path
-        self.file = TiliaFile(**data)
-        write_tilia_file_to_disk(TiliaFile(**data), str(path))
+        self.file = TiliaFile(**data, unknown_timelines=self.file.unknown_timelines)
+        write_tilia_file_to_disk(self.file, str(path))
 
         try:
             geometry, window_state = get(Get.WINDOW_GEOMETRY), get(Get.WINDOW_STATE)

--- a/tilia/file/migration.py
+++ b/tilia/file/migration.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import Callable
 
 from tilia.constants import VERSION
+from tilia.timelines.timeline_kinds import TimelineKind
 
 Migration = Callable[[dict], dict]
 
@@ -69,6 +70,23 @@ MIGRATIONS: list[tuple[str, Migration]] = [
     ("0.1.1", _to_0_1_1_display_position_to_ordinal),
     ("0.7.0", _to_0_7_0_timeline_kind),
 ]
+
+
+def _is_known_kind(kind: str | None) -> bool:
+    try:
+        TimelineKind(kind)
+    except ValueError:
+        return False
+    return True
+
+
+def find_unknown_timeline_kinds(data: dict) -> dict[str, str]:
+    return {
+        id: kind
+        for id, timeline in data.get("timelines", {}).items()
+        if isinstance(timeline, dict)
+        and not _is_known_kind(kind := timeline.get("kind"))
+    }
 
 
 def migrate(data: dict, app_version: str = VERSION) -> tuple[dict, list[str]]:

--- a/tilia/file/migration.py
+++ b/tilia/file/migration.py
@@ -1,0 +1,89 @@
+"""Upgrade ``.tla`` file data across TiLiA versions.
+
+Adding a migration
+------------------
+Write a function ``dict -> dict`` that performs one breaking-change upgrade and
+append ``(target_version, function)`` to ``MIGRATIONS`` in ascending version
+order. Keep each function defensive (a no-op when the field it touches is
+absent).
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from tilia.constants import VERSION
+
+Migration = Callable[[dict], dict]
+
+
+def _parse_version(version: str) -> tuple[int, ...]:
+    """Parse a version string into a comparable tuple of ints.
+
+    Reads the leading integer of each dot-separated segment, so suffixes
+    are ignored (``"0.7.0rc1"`` -> ``(0, 7, 0)``).
+    """
+    parts: list[int] = []
+    for segment in version.split("."):
+        digits = ""
+        for char in segment:
+            if not char.isdigit():
+                break
+            digits += char
+        if not digits:
+            break
+        parts.append(int(digits))
+    return tuple(parts) or (0,)
+
+
+def is_from_newer_version(data: dict, app_version: str = VERSION) -> bool:
+    return _parse_version(data.get("version", "0.0.0")) > _parse_version(app_version)
+
+
+def _to_0_1_1_display_position_to_ordinal(data: dict) -> dict:
+    """Rename each timeline's ``display_position`` to ``ordinal``.
+
+    ``ordinal`` is 1-based; the old ``display_position`` was 0-based.
+    """
+    for timeline in data.get("timelines", {}).values():
+        if "display_position" in timeline:
+            timeline["ordinal"] = timeline.pop("display_position") + 1
+    return data
+
+
+def _to_0_7_0_timeline_kind(data: dict) -> dict:
+    """Shorten the serialized timeline ``kind``.
+
+    TiLiA < 0.7 wrote the kind as e.g. ``"MARKER_TIMELINE"``; 0.7 writes the
+    ``Timeline`` subclass name without the suffix, e.g. ``"Marker"``.
+    """
+    for timeline in data.get("timelines", {}).values():
+        kind = timeline.get("kind", "")
+        if kind.endswith("_TIMELINE"):
+            timeline["kind"] = kind.replace("_TIMELINE", "").capitalize()
+    return data
+
+
+# Ascending by target version. See module docstring before editing.
+MIGRATIONS: list[tuple[str, Migration]] = [
+    ("0.1.1", _to_0_1_1_display_position_to_ordinal),
+    ("0.7.0", _to_0_7_0_timeline_kind),
+]
+
+
+def migrate(data: dict, app_version: str = VERSION) -> tuple[dict, list[str]]:
+    """Upgrade ``data`` from its stored version up to ``app_version``.
+
+    Applies, in order, every migration whose target is newer than the file's
+    version and not newer than ``app_version``. Mutates and returns ``data``
+    along with the list of target versions that were applied.
+    """
+    file_version = _parse_version(data.get("version", "0.0.0"))
+    app = _parse_version(app_version)
+    applied: list[str] = []
+    for target, function in MIGRATIONS:
+        if file_version < _parse_version(target) <= app:
+            data = function(data)
+            data["version"] = target
+            applied.append(target)
+    return data, applied

--- a/tilia/file/tilia_file.py
+++ b/tilia/file/tilia_file.py
@@ -13,6 +13,10 @@ class TiliaFile:
     timelines_hash: str = ""
     app_name: str = tilia.constants.APP_NAME
     version: str = tilia.constants.VERSION
+    # tls not recognised in this version; stored so they can be saved back out without loss.
+    unknown_timelines: dict = field(default_factory=dict)
+    # tls not recognised in this version; stored temporarily so the app reconises the need to prompt to save the discard.
+    deleted_timelines: dict = field(default_factory=dict)
 
 
 def validate_tla_data(data: dict) -> tuple[bool, str]:

--- a/tilia/requests/get.py
+++ b/tilia/requests/get.py
@@ -30,6 +30,7 @@ class Get(Enum):
     FROM_USER_SHOULD_SAVE_CHANGES = auto()
     FROM_USER_STRING = auto()
     FROM_USER_TILIA_FILE_PATH = auto()
+    FROM_USER_UNKNOWN_TIMELINE_KIND_ACTION = auto()
     FROM_USER_YES_OR_NO = auto()
     ID = auto()
     IS_FILE_MODIFIED = auto()

--- a/tilia/timelines/collection/collection.py
+++ b/tilia/timelines/collection/collection.py
@@ -230,8 +230,6 @@ class Timelines:
         data_copy = copy.deepcopy(data)  # so pop does not modify original data
 
         for id, tl_data in data_copy.items():
-            if "display_position" in tl_data:
-                tl_data["ordinal"] = tl_data.pop("display_position") + 1
             kind = TimelineKind(tl_data.pop("kind"))
             self.create_timeline(kind, id=id, **tl_data)
 

--- a/tilia/timelines/collection/collection.py
+++ b/tilia/timelines/collection/collection.py
@@ -248,7 +248,10 @@ class Timelines:
         # create timelines that are only in restored state
         for id in list(set(timeline_states) - set(shared_tl_ids)):
             params = timeline_states[id].copy()
-            kind = TimelineKind(params.pop("kind"))
+            try:
+                kind = TimelineKind(params.pop("kind"))
+            except ValueError:
+                continue
             self.create_timeline(kind, id=id, **params)
 
     def _restore_timeline_state(self, timeline: Timeline, state: dict[str, dict]):

--- a/tilia/ui/cli/ui.py
+++ b/tilia/ui/cli/ui.py
@@ -50,6 +50,10 @@ class CLI:
             (Get.FROM_USER_RETRY_MEDIA_PATH, on_ask_retry_media_file),
             (Get.FROM_USER_RETRY_PDF_PATH, on_ask_retry_pdf_file),
             (Get.FROM_USER_MEDIA_PATH, on_ask_media_path),
+            (
+                Get.FROM_USER_UNKNOWN_TIMELINE_KIND_ACTION,
+                on_ask_unknown_timeline_kind_action,
+            ),
         }
         for request, callback in SERVES:
             serve(self, request, callback)
@@ -210,6 +214,25 @@ def on_ask_retry_media_file() -> bool:
 
 def on_ask_retry_pdf_file() -> bool:
     return on_ask_yes_or_no("Invalid PDF", "Would you like to load another PDF file?")
+
+
+def on_ask_unknown_timeline_kind_action(kinds: list[str]) -> tuple[bool, bool]:
+    kind_list = ", ".join(sorted(set(kinds)))
+    # (proceed, delete)
+    outcomes = {
+        "cancel": (False, False),
+        "delete": (True, True),
+        "ignore": (True, False),
+    }
+    valid_answers = {x for opt in outcomes for x in (opt, opt[0])}
+    prompt = (
+        f"Unknown timeline type(s) found: {kind_list}. "
+        f"Delete, ignore (keep in file, unopened), or cancel opening? "
+        f"[delete/ignore/cancel]: "
+    )
+    while (ans := input(prompt).lower()) not in valid_answers:
+        pass
+    return next(v for opt, v in outcomes.items() if ans in (opt, opt[0]))
 
 
 def on_ask_media_path() -> tuple[bool, str]:

--- a/tilia/ui/dialog_manager.py
+++ b/tilia/ui/dialog_manager.py
@@ -4,6 +4,7 @@ from tilia.ui.dialogs.basic import (
     ask_for_float,
     ask_for_int,
     ask_for_string,
+    ask_unknown_timeline_kind_action,
     ask_yes_or_no,
 )
 from tilia.ui.dialogs.file import (
@@ -50,6 +51,10 @@ class DialogManager:
             (Get.FROM_USER_RETRY_PDF_PATH, ask_retry_pdf_file),
             (Get.FROM_USER_ADD_TIMELINE_WITHOUT_MEDIA, ask_add_timeline_without_media),
             (Get.FROM_USER_BEAT_TIMELINE_FILL_METHOD, ask_beat_timeline_fill_method),
+            (
+                Get.FROM_USER_UNKNOWN_TIMELINE_KIND_ACTION,
+                ask_unknown_timeline_kind_action,
+            ),
         }
 
         for request, callback in SERVES:

--- a/tilia/ui/dialogs/basic.py
+++ b/tilia/ui/dialogs/basic.py
@@ -56,6 +56,37 @@ def ask_yes_no_or_cancel(title: str, prompt: str) -> tuple[bool, bool]:
     )
 
 
+class UnknownTimelineKindMessageBox(QMessageBox):
+    def __init__(self, title: str, prompt: str) -> None:
+        super().__init__(
+            QMessageBox.Icon.Warning,
+            title,
+            prompt,
+            QMessageBox.StandardButton.Cancel
+            | QMessageBox.StandardButton.Discard
+            | QMessageBox.StandardButton.Ignore,
+            get(Get.MAIN_WINDOW),
+        )
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
+
+
+def ask_unknown_timeline_kind_action(kinds: list[str]) -> tuple[bool, bool]:
+    kind_list = ", ".join(sorted(set(kinds)))
+    title = "Unknown timeline type"
+    prompt = (
+        f"This file has timeline(s) of a type this version of TiLiA doesn't "
+        f"recognize: {kind_list}.\n\n"
+        "Discard them permanently or ignore them (keep them in the file, "
+        "unopened, in case a newer version can read them later)?"
+    )
+    result = UnknownTimelineKindMessageBox(title, prompt).exec()
+
+    return (
+        result != QMessageBox.StandardButton.Cancel,  # proceed
+        result == QMessageBox.StandardButton.Discard,  # delete
+    )
+
+
 class YesOrNoMessageBox(QMessageBox):
     def __init__(self, title: str, prompt: str) -> None:
         super().__init__(


### PR DESCRIPTION
## Summary

Adds version handling when opening `.tla` files. Until now `open_tla` stored the
file `version` but never read it: opening a file written by a newer TiLiA silently
partial-loaded and could drop unknown data on save, and older-format upgrades were
done with ad-hoc shims scattered inside `deserialize_timelines`.

This PR:

- **Warns + asks confirmation** before opening a file from a newer TiLiA version
  (`open_tla` → `Get.FROM_USER_YES_OR_NO`). Declining aborts the load.
- Adds `tilia/file/migration.py`: an ordered list of small, composable
  `dict -> dict` migrations applied to the raw file data on load.
- Moves the inline `display_position -> ordinal` shim out of
  `deserialize_timelines` into the registry (target `0.1.1`), giving version
  upgrades a single source of truth.
- Registers the upcoming v0.7 timeline-kind rename
  (`MARKER_TIMELINE -> Marker`) as a **dormant** migration (target `0.7.0`)

## Follow-up

When syncing onto the `v0.7.0` branch, delete the inline `_get_timeline_class_string`
shim there — the dormant `0.7.0` migration replaces it.
