### PR TITLE
fix: comments icon no longer blocks dragging hierarchy handles

### DIFF
--- a/tests/ui/timelines/hierarchy/test_hierarchy_ui.py
+++ b/tests/ui/timelines/hierarchy/test_hierarchy_ui.py
@@ -309,6 +309,14 @@ class TestCommentsIndicator:
         hui.set_data("end", 100)
         assert hui.comments_icon.isVisible()
 
+    def test_does_not_stack_above_drag_handles(self, tlui):
+        # Regression: the comments emoji's bounding box overhangs the end
+        # handle's x. If the icon stacks above the handle it wins the itemAt
+        # hit-test and the boundary can't be dragged.
+        hui = self.create_hierarchy_ui(tlui, comments="something")
+        assert hui.comments_icon.zValue() < hui.start_handle.zValue()
+        assert hui.comments_icon.zValue() < hui.end_handle.zValue()
+
 
 class TestDoubleClick:
     def test_posts_seek(self, tlui, tilia_state):

--- a/tilia/ui/timelines/hierarchy/handles.py
+++ b/tilia/ui/timelines/hierarchy/handles.py
@@ -6,6 +6,10 @@ from PySide6.QtWidgets import QGraphicsItemGroup, QGraphicsLineItem, QGraphicsRe
 
 from tilia.ui.timelines.cursors import CursorMixIn
 
+# Drag handles must sit above the decorative overlays (label, comments and
+# loop icons at z = level + 1 in element.py) so their clicks aren't stolen.
+HANDLE_Z = 100
+
 
 class HierarchyBodyHandle(CursorMixIn, QGraphicsRectItem):
     def __init__(
@@ -26,7 +30,7 @@ class HierarchyBodyHandle(CursorMixIn, QGraphicsRectItem):
 
     def set_position(self, x, width, height, tl_height, bottom_margin):
         self.setRect(self.get_rect(x, width, height, tl_height, bottom_margin))
-        self.setZValue(0)
+        self.setZValue(HANDLE_Z)
 
     @staticmethod
     def get_rect(x, width, height, tl_height, bottom_margin):

--- a/tilia/ui/timelines/scene.py
+++ b/tilia/ui/timelines/scene.py
@@ -8,6 +8,7 @@ from tilia.settings import settings
 
 class TimelineScene(QGraphicsScene):
     LABEL_Y_MARGIN = 3
+    LOOP_BOX_Z = -100
 
     def __init__(
         self,
@@ -73,9 +74,7 @@ class TimelineScene(QGraphicsScene):
         self.set_loop_box_color(QColor(settings.get("general", "loop_box_shade")))
         self.loop_box.setVisible(False)
         self.addItem(self.loop_box)
-        self.loop_box.setZValue(
-            -len(settings.get("hierarchy_timeline", "default_colors")) - 1
-        )
+        self.loop_box.setZValue(self.LOOP_BOX_Z)
 
     def set_loop_box_color(self, color):
         pen = QPen()


### PR DESCRIPTION
The comments indicator on adjacent hierarchy units sat on top of the body drag handles, making those boundaries impossible to drag. Reported on macOS; the glyph is narrower on Windows, so it may not reproduce there.

**Cause:** the comments icon has `z = level + 1`, above the drag handles' `z = 0`. Click dispatch uses `QGraphicsView.itemAt`, which returns the topmost item — and the icon's bounding box overhangs the handle's x, so clicks resolved to the icon, which isn't a drag trigger.

**Fix:** raise the drag handles above the decorative overlays (`HANDLE_Z = 100`) so they always win the hit-test. Handles were already above all bodies, so only handle-vs-icon stacking changes. Also covers the loop icon's matching overlap with the start handle.

Added a regression test asserting the comments icon stacks below both handles.