### PR TITLE
fix: suppress fromIccProfile Qt warning flood on startup

### DIFF
--- a/tests/ui/test_qtui.py
+++ b/tests/ui/test_qtui.py
@@ -309,6 +309,7 @@ class TestHandleQtLogMessage:
         [
             "QFont::setPixelSize: Pixel size <= 0 (0)",
             "QWindowsFontEngineDirectWrite::addGlyphsToPath: GetGlyphRunOutline failed (Der Vorgang wurde erfolgreich beendet.)",
+            "fromIccProfile: Failed to parse description",
         ],
     )
     def test_known_noise_warning_is_suppressed(self, noisy_msg):

--- a/tilia/boot.py
+++ b/tilia/boot.py
@@ -44,6 +44,10 @@ def handle_exception(type, value, tb):
 QT_LOG_NOISE_PATTERNS = (
     "QFont::setPixelSize: Pixel size <= 0",
     "QWindowsFontEngineDirectWrite::addGlyphsToPath: GetGlyphRunOutline failed",
+    # Emitted by QtGui's ICC parser when it can't read the description tag of a
+    # colour profile - on macOS the display profile is re-parsed for every
+    # native window, flooding the log on startup. Purely cosmetic.
+    "fromIccProfile: Failed to parse description",
 )
 
 


### PR DESCRIPTION
## Problem

On macOS, running TiLiA floods the log with hundreds of:

```
[QtWarningMsg] None:0 - fromIccProfile: Failed to parse description
```

They appear at startup, before any file or user content is loaded.

## Root cause

The message comes from QtGui's ICC parser (category `qt.gui.icc`), **not**
from any TiLiA asset — all bundled icons are SVG and carry no ICC profile.
Qt reads the **display colour profile** that macOS provides and fails to
parse its `desc` (description) tag. The parse is repeated **once per native
window/widget**, so a single `QMainWindow` already yields ~17 lines; TiLiA's
main window plus its dock widgets and toolbars turn that into a flood.

Isolated on a real cocoa display:

| Setup | `fromIccProfile` lines |
|-------|-----------------------:|
| bare `QApplication` | 1 |
| `QIcon.fromTheme('tilia')` | 1 |
| **`QApplication` + `QMainWindow.show()`** | **17** |
| `QWebEngineView` | 1 |

The warning is purely cosmetic — the images render correctly. There is
nothing to strip: the profile belongs to the user's monitor, not to a file
TiLiA ships or loads.

## Fix

Add the message to `QT_LOG_NOISE_PATTERNS` in `boot.py`, so the existing Qt
log handler drops it — the same treatment already applied to other harmless
Qt rendering noise (`QFont::setPixelSize`, `GetGlyphRunOutline`). Filtering
is by message substring, so it is source-agnostic.

## Tests

Added `"fromIccProfile: Failed to parse description"` to the parametrized
`test_known_noise_warning_is_suppressed` case. `TestHandleQtLogMessage`
passes (14 tests); ruff + black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
