### PR TITLE
fix: ignore stale YouTube duration reports

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -215,6 +215,55 @@ class TestFileLoad:
         assert tilia_state.media_path == media_path
         assert tilia_state.duration == 101
 
+    def test_stale_youtube_duration_after_switching_video_is_ignored(
+        self, tilia, tilia_state, qtui, tmp_path
+    ):
+        # Regression test: opening two YouTube-backed files in a row reuses
+        # the same YouTubePlayer/QWebEngineView instance (media type doesn't
+        # change, so _change_player_type never tears it down). A
+        # getDuration() JS query issued for the first video can resolve
+        # after the second video has already loaded -- on_media_duration_available
+        # must ignore a result tagged with a video_id that's no longer the
+        # one currently loaded, rather than silently overwriting the
+        # duration of the (unrelated) now-open file.
+        def make_file(tmp_name: str, media_path: str, media_length: float):
+            file_data = tests.utils.get_blank_file_data()
+            file_data["media_path"] = media_path
+            file_data["media_metadata"]["media length"] = media_length
+            path = tmp_path / tmp_name
+            path.write_text(json.dumps(file_data))
+            return path
+
+        file_a = make_file(
+            "file_a.tla", "https://www.youtube.com/watch?v=aaaaaaaaaaa", 100
+        )
+        file_b = make_file(
+            "file_b.tla", "https://www.youtube.com/watch?v=bbbbbbbbbbb", 200
+        )
+
+        with (
+            Serve(Get.FROM_USER_TILIA_FILE_PATH, (True, file_a)),
+            Serve(Get.PLAYER_CLASS, YouTubePlayer),
+        ):
+            commands.execute("file.open")
+        video_id_a = tilia.player.video_id
+        assert tilia_state.duration == 100
+
+        with Serve(Get.FROM_USER_TILIA_FILE_PATH, (True, file_b)):
+            commands.execute("file.open")
+        video_id_b = tilia.player.video_id
+        assert video_id_b != video_id_a
+        assert tilia_state.duration == 200
+
+        # Simulate file A's getDuration() echo resolving late, after file B
+        # has already loaded into the same, reused player instance.
+        tilia.player.on_media_duration_available(999.0, requested_video_id=video_id_a)
+        assert tilia_state.duration == 200
+
+        # A report tagged with the currently-loaded video is still honored.
+        tilia.player.on_media_duration_available(201.0, requested_video_id=video_id_b)
+        assert tilia_state.duration == 201
+
 
 class TestMediaLoad:
     @staticmethod

--- a/tilia/media/player/youtube.py
+++ b/tilia/media/player/youtube.py
@@ -25,6 +25,7 @@ class PlayerTracker(QObject):
         set_is_playing,
         set_playback_rate,
         display_error,
+        get_video_id,
     ):
         super().__init__()
         self.on_duration_available = on_duration_available
@@ -34,6 +35,7 @@ class PlayerTracker(QObject):
         self.set_playback_rate = set_playback_rate
         self.player_toolbar_enabled = False
         self.display_error = display_error
+        self.get_video_id = get_video_id
 
     @Slot("float")
     def on_new_time(self, time):
@@ -43,7 +45,17 @@ class PlayerTracker(QObject):
     def on_player_state_change(self, state):
         if state == self.State.UNSTARTED.value:
             post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.WAITING_FOR_YOUTUBE)
-            self.page.runJavaScript("getDuration()", self.on_duration_available)
+            # Capture which video this query is for -- by the time the JS
+            # round-trip resolves, a different video may already be loaded
+            # (e.g. the user opened another YouTube-backed file), and a
+            # stale duration must not be attributed to it.
+            requested_video_id = self.get_video_id()
+            self.page.runJavaScript(
+                "getDuration()",
+                lambda duration: self.on_duration_available(
+                    duration, requested_video_id
+                ),
+            )
             self.player_toolbar_enabled = False
         elif state == self.State.PLAYING.value:
             if not self.player_toolbar_enabled:
@@ -83,6 +95,7 @@ class YouTubePlayer(Player):
 
     def __init__(self):
         super().__init__()
+        self.video_id = None
         self._setup_web_engine()
         self._setup_web_channel()
 
@@ -102,6 +115,7 @@ class YouTubePlayer(Player):
             self.set_is_playing,
             self._engine_set_playback_rate,
             self.display_error,
+            lambda: self.video_id,
         )
         self.channel.registerObject("backend", self.shared_object)
         self.view.page().setWebChannel(self.channel)
@@ -146,11 +160,17 @@ class YouTubePlayer(Player):
 
         self.is_media_loaded = True
 
-    def on_media_duration_available(self, duration):
+    def on_media_duration_available(self, duration, requested_video_id=None):
+        # requested_video_id is the video this query was issued for; if a
+        # different video has loaded by the time the JS round-trip resolves
+        # (e.g. the user opened another YouTube-backed file), this result
+        # is stale and must not be applied.
+        if requested_video_id is not None and requested_video_id != self.video_id:
+            return
         if duration == self.duration:
             return
         if not duration:
-            return self.retry_get_duration()
+            return self.retry_get_duration(requested_video_id)
 
         super().on_media_duration_available(duration)
 
@@ -164,8 +184,12 @@ class YouTubePlayer(Player):
                 MediaTimeChangeReason.PLAYBACK,
             )
 
-    def retry_get_duration(self):
-        QTimer.singleShot(500, self.view, self._engine_get_media_duration)
+    def retry_get_duration(self, requested_video_id=None):
+        QTimer.singleShot(
+            500,
+            self.view,
+            lambda: self._engine_get_media_duration(requested_video_id),
+        )
 
     def display_error(self, message: str):
         tilia.errors.display(
@@ -225,9 +249,12 @@ class YouTubePlayer(Player):
         self.video_id = None
         self.shared_object.player_toolbar_enabled = False
 
-    def _engine_get_media_duration(self):
+    def _engine_get_media_duration(self, requested_video_id=None):
         self.view.page().runJavaScript(
-            "getDuration()", self.on_media_duration_available
+            "getDuration()",
+            lambda duration: self.on_media_duration_available(
+                duration, requested_video_id
+            ),
         )
 
     def _engine_exit(self):


### PR DESCRIPTION
getDuration() is queried asynchronously on each UNSTARTED player-state transition. Opening a second YouTube-backed file reuses the same YouTubePlayer/QWebEngineView instance (media type unchanged, so _change_player_type never tears it down), so a query issued for the first video can resolve after the second has already loaded, silently overwriting App.duration with a value that belongs to the wrong video.

Thread the video_id the query was issued for through the callback chain and discard results that no longer match the currently loaded video.