### PR TITLE
ci: fix release asset-count check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,13 +175,14 @@ jobs:
 
       - name: Check output
         env:
-          GH_TOKEN: ${{ github.token }}
+          RELEASE_ASSETS: ${{ steps.release.outputs.assets }}
         run: |
           echo "Counting assets released..."
-          ASSET_COUNT=$(gh release view ${{ github.ref_name }} --json assets --jq '.assets | length')
+          ASSET_COUNT=$(jq 'length' <<< "$RELEASE_ASSETS")
           if [ "$ASSET_COUNT" -eq 4 ]; then
             echo "4 assets found!"
           else
             echo "::error::Incorrect number of assets! Got $ASSET_COUNT. Potential errors in build."
+            echo "assets: $RELEASE_ASSETS"
             exit 1
           fi


### PR DESCRIPTION
Closes #551.

The deploy job's "Check output" step called `gh release view` without --repo, and the job never runs actions/checkout, so gh had no git remote to infer the target repository from and failed immediately with "fatal: not a git repository" (seen on the v0.6.3 release run) - even though the release itself succeeded.

Read the asset count from the Upload step's own JSON output instead, which needs neither git nor an extra API call. Counting via `jq length` also avoids the out-of-range expression-indexing risk of the previous fromJSON(...)[3]/[4] check this had been swapped away from.