### PR TITLE
fix: scope CI pip cache key per Python version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -59,9 +59,9 @@ jobs:
     - uses: actions/cache@v5
       with:
         path: ${{ matrix.path }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
-         ${{ runner.os }}-pip-
+         ${{ runner.os }}-pip-${{ matrix.python-version }}-
 
     - name: Install Python dependencies
       run: |


### PR DESCRIPTION
All Linux/macOS/Windows matrix lanes shared one cache key keyed only on runner.os + pyproject.toml hash. GitHub Actions caches are write-once per key, so once a fast lane (3.10-3.12) populated the cache, every other lane got a cache hit and never saved its own wheels. The 3.13 lane never got to persist its from-source numpy build, so it rebuilt numpy from source (~3min) on every single run instead of reusing a cached wheel.